### PR TITLE
Soften hero banner overlay

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -204,6 +204,15 @@
     50% { opacity: 0.8; }
   }
 
+  @keyframes hero-pan {
+    0%, 100% {
+      background-position: 0% 50%;
+    }
+    50% {
+      background-position: 100% 50%;
+    }
+  }
+
   @keyframes gradient-shift {
     0% {
       background-position: 0% 50%;
@@ -224,10 +233,22 @@
     animation: pulse-soft 2s ease-in-out infinite;
   }
 
+  .hero-background {
+    position: absolute;
+    inset: 0;
+    background-image: url("/img/banner1.jpg");
+    background-size: 140% auto;
+    background-repeat: no-repeat;
+    background-position: 0% 50%;
+    animation: hero-pan 32s ease-in-out infinite;
+    transform: scale(1.05);
+    filter: brightness(1.05) saturate(1.08);
+  }
+
   .gradient-hero {
-    background: linear-gradient(-45deg, 
-      hsl(215 85% 25%), 
-      hsl(215 85% 35%), 
+    background: linear-gradient(-45deg,
+      hsl(215 85% 25%),
+      hsl(215 85% 35%),
       hsl(145 65% 35%), 
       hsl(145 65% 45%)
     );

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -120,29 +120,39 @@ const Home = ({ currentUser, onLogin, onLogout }) => {
       <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
         {/* Hero Section */}
         <section className="text-center mb-12">
-          <div className="gradient-hero rounded-3xl p-12 text-white shadow-strong">
-            <div className="flex justify-center mb-6">
-              <School className="h-20 w-20 float-animation" />
-            </div>
-            <h1 className="text-4xl md:text-5xl font-bold mb-4">
-              {schoolProfile?.nama || "SMA Negeri 1 Nosu"}
-            </h1>
-            <p className="text-xl md:text-2xl mb-2 opacity-90">
-              Sulawesi Barat
-            </p>
-            <p className="text-lg opacity-75 max-w-2xl mx-auto">
-              {schoolProfile?.visi ||
-                "Sistem Informasi Akademik Digital untuk transparansi dan kemudahan akses informasi pendidikan"}
-            </p>
-            <div className="mt-8 flex flex-wrap justify-center gap-4">
-              <Badge variant="secondary" className="px-4 py-2 text-sm">
-                <Target className="h-4 w-4 mr-2" />
-                Unggul dalam Prestasi
-              </Badge>
-              <Badge variant="secondary" className="px-4 py-2 text-sm">
-                <Heart className="h-4 w-4 mr-2" />
-                Berkarakter Mulia
-              </Badge>
+          <div className="relative overflow-hidden rounded-3xl shadow-strong">
+            <div
+              className="hero-background"
+              aria-hidden="true"
+            />
+            <div
+              className="absolute inset-0 bg-gradient-to-r from-primary/70 via-primary/30 to-primary/70"
+              aria-hidden="true"
+            />
+            <div className="relative z-10 p-8 sm:p-12 text-white">
+              <div className="flex justify-center mb-6">
+                <School className="h-20 w-20 float-animation drop-shadow-[0_10px_18px_rgba(0,0,0,0.4)]" />
+              </div>
+              <h1 className="text-4xl md:text-5xl font-bold mb-4 drop-shadow-[0_10px_18px_rgba(0,0,0,0.35)]">
+                {schoolProfile?.nama || "SMA Negeri 1 Nosu"}
+              </h1>
+              <p className="text-xl md:text-2xl mb-2 opacity-95 drop-shadow-[0_8px_14px_rgba(0,0,0,0.35)]">
+                Sulawesi Barat
+              </p>
+              <p className="text-lg opacity-90 max-w-2xl mx-auto drop-shadow-[0_8px_14px_rgba(0,0,0,0.35)]">
+                {schoolProfile?.visi ||
+                  "Sistem Informasi Akademik Digital untuk transparansi dan kemudahan akses informasi pendidikan"}
+              </p>
+              <div className="mt-8 flex flex-wrap justify-center gap-4">
+                <Badge variant="secondary" className="px-4 py-2 text-sm">
+                  <Target className="h-4 w-4 mr-2" />
+                  Unggul dalam Prestasi
+                </Badge>
+                <Badge variant="secondary" className="px-4 py-2 text-sm">
+                  <Heart className="h-4 w-4 mr-2" />
+                  Berkarakter Mulia
+                </Badge>
+              </div>
             </div>
           </div>
         </section>


### PR DESCRIPTION
## Summary
- lighten the hero overlay gradient and add subtle drop shadows so the banner image appears more vibrant while text stays legible
- boost the banner animation background with mild brightness and saturation for improved color depth

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d61fefded88332aea2670791b3082b