### PR TITLE
Add semester selection and filtering to teacher dashboard

### DIFF
--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -402,6 +402,13 @@ const apiService = {
       const response = await this.authFetch(
         appendQuery(`${API_BASE_URL}/guru/grades`, query)
       );
+      if (response?.success === false) {
+        const error = new Error(
+          response?.message || "Gagal memuat data nilai"
+        );
+        error.code = response?.code;
+        throw error;
+      }
       return normalizeData(response.data);
     } else {
       const grades = JSON.parse(
@@ -433,6 +440,13 @@ const apiService = {
       const response = await this.authFetch(
         appendQuery(`${API_BASE_URL}/guru/attendance`, query)
       );
+      if (response?.success === false) {
+        const error = new Error(
+          response?.message || "Gagal memuat data kehadiran"
+        );
+        error.code = response?.code;
+        throw error;
+      }
       return normalizeData(response.data);
     } else {
       const attendance = JSON.parse(


### PR DESCRIPTION
## Summary
- load available semesters on the teacher dashboard and expose selectors in the dashboard header and grade/attendance dialogs
- filter teacher grade and attendance data by the chosen semester, including semester labels in table and card displays
- surface semester-related validation errors to the UI and guard API helpers against SEMESTER_NOT_FOUND responses

## Testing
- npm run lint *(fails: existing lint violations outside the touched files)*

------
https://chatgpt.com/codex/tasks/task_e_68f5ccef52ec8332a44e294b74f6eced