### PR TITLE
feat: integrate semester metadata into walikelas dashboard

### DIFF
--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -1449,6 +1449,13 @@ const apiService = {
           query
         )
       );
+      if (response?.success === false) {
+        const error = new Error(
+          response?.message || "Gagal memuat data nilai kelas"
+        );
+        error.code = response?.code;
+        throw error;
+      }
       return normalizeData(response.data);
     } else {
       const grades = JSON.parse(
@@ -1485,6 +1492,13 @@ const apiService = {
           query
         )
       );
+      if (response?.success === false) {
+        const error = new Error(
+          response?.message || "Gagal memuat data kehadiran kelas"
+        );
+        error.code = response?.code;
+        throw error;
+      }
       return normalizeData(response.data);
     } else {
       const attendance = JSON.parse(
@@ -1711,6 +1725,13 @@ const apiService = {
           query
         )
       );
+      if (response?.success === false) {
+        const error = new Error(
+          response?.message || "Gagal memuat raport siswa"
+        );
+        error.code = response?.code;
+        throw error;
+      }
       return response.data;
     } else {
       const students = JSON.parse(


### PR DESCRIPTION
## Summary
- replace the walikelas period selector with semester data from the backend and surface its metadata across the dashboard
- send semesterId to class data endpoints and surface "Semester tidak ditemukan" errors when the backend rejects a selection
- show the selected semester details within the stats and reports views and propagate the label to derived student report listings

## Testing
- npm run lint *(fails: repository contains pre-existing lint errors around `any` usage and Tailwind config requirements)*

------
https://chatgpt.com/codex/tasks/task_e_68f5d07062c483328308bd36a348dd69