### PR TITLE
Enhance report generation with semester metadata

### DIFF
--- a/src/pages/siswa/Dashboard.tsx
+++ b/src/pages/siswa/Dashboard.tsx
@@ -431,6 +431,30 @@ const StudentDashboard = ({ currentUser, onLogout }) => {
         ...reportData,
         semesterInfo:
           resolvedSemesterMetadata || metadata || reportData?.semesterInfo || undefined,
+        semesterTanggalMulai:
+          reportData?.semesterTanggalMulai ??
+          resolvedSemesterMetadata?.tanggalMulai ??
+          metadata?.tanggalMulai ??
+          (reportData as SemesterRecord)?.startDate ??
+          null,
+        semesterTanggalSelesai:
+          reportData?.semesterTanggalSelesai ??
+          resolvedSemesterMetadata?.tanggalSelesai ??
+          metadata?.tanggalSelesai ??
+          (reportData as SemesterRecord)?.endDate ??
+          null,
+        semesterJumlahHariBelajar:
+          reportData?.semesterJumlahHariBelajar ??
+          resolvedSemesterMetadata?.jumlahHariBelajar ??
+          metadata?.jumlahHariBelajar ??
+          (reportData as SemesterRecord)?.jumlahHariBelajar ??
+          null,
+        semesterCatatan:
+          reportData?.semesterCatatan ??
+          resolvedSemesterMetadata?.catatan ??
+          metadata?.catatan ??
+          (reportData as SemesterRecord)?.catatan ??
+          null,
       };
 
       printReport(enrichedReportData);

--- a/src/pages/walikelas/Dashboard.tsx
+++ b/src/pages/walikelas/Dashboard.tsx
@@ -601,6 +601,30 @@ const WalikelasaDashboard = ({ currentUser, onLogout }) => {
         ...reportData,
         semesterInfo:
           resolvedSemesterMetadata || reportData?.semesterInfo || undefined,
+        semesterTanggalMulai:
+          reportData?.semesterTanggalMulai ??
+          resolvedSemesterMetadata?.tanggalMulai ??
+          reportData?.semesterInfo?.tanggalMulai ??
+          reportData?.semesterInfo?.startDate ??
+          null,
+        semesterTanggalSelesai:
+          reportData?.semesterTanggalSelesai ??
+          resolvedSemesterMetadata?.tanggalSelesai ??
+          reportData?.semesterInfo?.tanggalSelesai ??
+          reportData?.semesterInfo?.endDate ??
+          null,
+        semesterJumlahHariBelajar:
+          reportData?.semesterJumlahHariBelajar ??
+          resolvedSemesterMetadata?.jumlahHariBelajar ??
+          reportData?.semesterInfo?.jumlahHariBelajar ??
+          reportData?.semesterInfo?.learningDays ??
+          null,
+        semesterCatatan:
+          reportData?.semesterCatatan ??
+          resolvedSemesterMetadata?.catatan ??
+          reportData?.semesterInfo?.catatan ??
+          reportData?.semesterInfo?.notes ??
+          null,
       };
 
       printReport(enrichedReportData); // langsung kirim ke printer/pdf


### PR DESCRIPTION
## Summary
- extend report printing helpers to understand semester metadata including start/end dates, learning days, and notes
- update report HTML header to render the semester period, date range, study days, and notes
- ensure student and homeroom dashboards pass normalized semester metadata when printing reports

## Testing
- npm run lint *(fails: pre-existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68f5d62587fc8332aa8b8e448ad472d9