### PR TITLE
Refactor dashboards to use shared semester hook

### DIFF
--- a/src/components/guru/TeacherAttendanceDialog.tsx
+++ b/src/components/guru/TeacherAttendanceDialog.tsx
@@ -17,14 +17,24 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-import { UseTeacherDashboardReturn } from "@/hooks/use-teacher-dashboard";
+import {
+  type Semester,
+  UseTeacherDashboardReturn,
+} from "@/hooks/use-teacher-dashboard";
 
 type TeacherAttendanceDialogProps = {
   dashboard: UseTeacherDashboardReturn;
+  buildSemesterLabel: (semester: Semester | null) => string | null;
+  getSemesterLabelById: (
+    id: string | number | null,
+    fallback?: Semester | null
+  ) => string;
 };
 
 export function TeacherAttendanceDialog({
   dashboard,
+  buildSemesterLabel,
+  getSemesterLabelById,
 }: TeacherAttendanceDialogProps) {
   const {
     showAttendanceDialog,
@@ -35,8 +45,6 @@ export function TeacherAttendanceDialog({
     subjects,
     students,
     semesters,
-    buildSemesterLabel,
-    getSemesterLabelById,
     getSubjectName,
     getClassesName,
     getStudentName,

--- a/src/components/guru/TeacherGradeDialog.tsx
+++ b/src/components/guru/TeacherGradeDialog.tsx
@@ -17,13 +17,25 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-import { UseTeacherDashboardReturn } from "@/hooks/use-teacher-dashboard";
+import {
+  type Semester,
+  UseTeacherDashboardReturn,
+} from "@/hooks/use-teacher-dashboard";
 
 type TeacherGradeDialogProps = {
   dashboard: UseTeacherDashboardReturn;
+  buildSemesterLabel: (semester: Semester | null) => string | null;
+  getSemesterLabelById: (
+    id: string | number | null,
+    fallback?: Semester | null
+  ) => string;
 };
 
-export function TeacherGradeDialog({ dashboard }: TeacherGradeDialogProps) {
+export function TeacherGradeDialog({
+  dashboard,
+  buildSemesterLabel,
+  getSemesterLabelById,
+}: TeacherGradeDialogProps) {
   const {
     showGradeDialog,
     handleGradeDialogOpenChange,
@@ -33,8 +45,6 @@ export function TeacherGradeDialog({ dashboard }: TeacherGradeDialogProps) {
     subjects,
     students,
     semesters,
-    buildSemesterLabel,
-    getSemesterLabelById,
     getClassesName,
     getStudentName,
     handleAddGrade,

--- a/src/hooks/use-dashboard-semester.ts
+++ b/src/hooks/use-dashboard-semester.ts
@@ -1,0 +1,264 @@
+import { useCallback } from "react";
+import { formatAcademicPeriod, formatDate } from "@/utils/helpers";
+
+export type DashboardSemesterRecord = {
+  id?: string | number;
+  tahunAjaran?: string | null;
+  tahun?: string | null;
+  academicYear?: string | null;
+  year?: string | null;
+  semester?: number | string | null;
+  semesterNumber?: number | string | null;
+  term?: number | string | null;
+  tanggalMulai?: string | null;
+  startDate?: string | null;
+  tanggalSelesai?: string | null;
+  endDate?: string | null;
+  jumlahHariBelajar?: number | string | null;
+  learningDays?: number | string | null;
+  totalSchoolDays?: number | string | null;
+  hariEfektif?: number | string | null;
+  catatan?: string | null;
+  notes?: string | null;
+  keterangan?: string | null;
+  isActive?: boolean;
+  label?: string | null;
+};
+
+export type DashboardSemesterMetadata = {
+  id: string | null;
+  tahunAjaran: string | null;
+  semesterNumber: number | string | null;
+  tanggalMulai: string | null;
+  tanggalSelesai: string | null;
+  jumlahHariBelajar: number | string | null;
+  catatan: string;
+  isActive: boolean;
+};
+
+interface UseDashboardSemesterParams {
+  semesters?: DashboardSemesterRecord[];
+}
+
+export const useDashboardSemester = (
+  params: UseDashboardSemesterParams = {}
+) => {
+  const { semesters = [] } = params;
+
+  const normalizeSemesterMetadata = useCallback(
+    (
+      semesterItem?: DashboardSemesterRecord | null
+    ): DashboardSemesterMetadata | null => {
+      if (!semesterItem) return null;
+
+      const rawSemester =
+        semesterItem.semester ??
+        semesterItem.semesterNumber ??
+        semesterItem.term ??
+        null;
+
+      let semesterNumber: number | string | null = null;
+      if (rawSemester !== null && rawSemester !== undefined) {
+        const numericValue = Number(rawSemester);
+        semesterNumber = Number.isNaN(numericValue) ? rawSemester : numericValue;
+      }
+
+      return {
+        id: semesterItem.id !== undefined && semesterItem.id !== null
+          ? String(semesterItem.id)
+          : null,
+        tahunAjaran:
+          semesterItem.tahunAjaran ??
+          semesterItem.tahun ??
+          semesterItem.academicYear ??
+          semesterItem.year ??
+          null,
+        semesterNumber,
+        tanggalMulai: semesterItem.tanggalMulai ?? semesterItem.startDate ?? null,
+        tanggalSelesai: semesterItem.tanggalSelesai ?? semesterItem.endDate ?? null,
+        jumlahHariBelajar:
+          semesterItem.jumlahHariBelajar ??
+          semesterItem.learningDays ??
+          semesterItem.totalSchoolDays ??
+          semesterItem.hariEfektif ??
+          null,
+        catatan:
+          semesterItem.catatan ??
+          semesterItem.notes ??
+          semesterItem.keterangan ??
+          "",
+        isActive: Boolean(semesterItem.isActive),
+      };
+    },
+    []
+  );
+
+  const formatSemesterNumberLabel = useCallback(
+    (value: number | string | null | undefined): string | null => {
+      if (value === null || value === undefined || value === "") return null;
+
+      const numericValue = Number(value);
+      if (!Number.isNaN(numericValue)) {
+        if (numericValue === 1) return "Semester Ganjil";
+        if (numericValue === 2) return "Semester Genap";
+        return `Semester ${numericValue}`;
+      }
+
+      return typeof value === "string" ? value : null;
+    },
+    []
+  );
+
+  const buildSemesterTitle = useCallback(
+    (
+      metadata: DashboardSemesterMetadata | null,
+      includeActiveFlag = false
+    ): string => {
+      if (!metadata) return "Semester";
+
+      const parts: string[] = [];
+
+      if (metadata.tahunAjaran) {
+        parts.push(metadata.tahunAjaran);
+      }
+
+      const semesterLabel = formatSemesterNumberLabel(metadata.semesterNumber);
+      if (semesterLabel) {
+        parts.push(semesterLabel);
+      }
+
+      const baseLabel = parts.join(" - ") || "Semester";
+      const suffix = includeActiveFlag && metadata.isActive ? " (Aktif)" : "";
+      return `${baseLabel}${suffix}`;
+    },
+    [formatSemesterNumberLabel]
+  );
+
+  const buildSemesterDateRange = useCallback(
+    (metadata: DashboardSemesterMetadata | null): string | null => {
+      if (!metadata) return null;
+      if (!metadata.tanggalMulai || !metadata.tanggalSelesai) return null;
+      return `${formatDate(metadata.tanggalMulai)} - ${formatDate(
+        metadata.tanggalSelesai
+      )}`;
+    },
+    []
+  );
+
+  const formatStudyDays = useCallback(
+    (metadata: DashboardSemesterMetadata | null): string => {
+      if (!metadata || metadata.jumlahHariBelajar === null) return "-";
+      const numericValue = Number(metadata.jumlahHariBelajar);
+      if (!Number.isNaN(numericValue)) {
+        return `${numericValue} hari`;
+      }
+      return String(metadata.jumlahHariBelajar);
+    },
+    []
+  );
+
+  const buildSemesterLabel = useCallback(
+    (semesterItem: DashboardSemesterRecord | null): string | null => {
+      if (!semesterItem) return null;
+
+      const explicitLabel =
+        typeof semesterItem.label === "string" && semesterItem.label.trim()
+          ? semesterItem.label
+          : null;
+      if (explicitLabel) {
+        return explicitLabel;
+      }
+
+      const metadata = normalizeSemesterMetadata(semesterItem);
+      if (!metadata) return null;
+
+      if (
+        !metadata.tahunAjaran &&
+        (metadata.semesterNumber === null || metadata.semesterNumber === undefined)
+      ) {
+        return null;
+      }
+
+      return formatAcademicPeriod(metadata);
+    },
+    [normalizeSemesterMetadata]
+  );
+
+  const getSemesterRecordById = useCallback(
+    (semesterId: string | number | null): DashboardSemesterRecord | null => {
+      if (!semesterId) return null;
+      return (
+        semesters.find((item) => String(item.id) === String(semesterId)) || null
+      );
+    },
+    [semesters]
+  );
+
+  const resolveSemesterMetadata = useCallback(
+    (
+      semesterId: string | number | null,
+      fallback?: DashboardSemesterRecord | null
+    ): DashboardSemesterMetadata | null => {
+      const record = getSemesterRecordById(semesterId) || fallback || null;
+      return normalizeSemesterMetadata(record);
+    },
+    [getSemesterRecordById, normalizeSemesterMetadata]
+  );
+
+  const getSemesterLabelById = useCallback(
+    (
+      semesterId: string | number | null,
+      fallback?: DashboardSemesterRecord | null
+    ): string => {
+      const label =
+        buildSemesterLabel(getSemesterRecordById(semesterId)) ||
+        buildSemesterLabel(fallback || null);
+
+      return label ?? "-";
+    },
+    [buildSemesterLabel, getSemesterRecordById]
+  );
+
+  const getSemesterOptionLabel = useCallback(
+    (semesterItem: DashboardSemesterRecord | null): string => {
+      const metadata = normalizeSemesterMetadata(semesterItem);
+      if (!metadata) return "Semester";
+
+      const baseLabel = buildSemesterTitle(metadata, true);
+      const dateRange = buildSemesterDateRange(metadata);
+      return dateRange ? `${baseLabel} (${dateRange})` : baseLabel;
+    },
+    [buildSemesterTitle, buildSemesterDateRange, normalizeSemesterMetadata]
+  );
+
+  const buildSemesterPeriodLabel = useCallback(
+    (metadata: DashboardSemesterMetadata | null): string => {
+      if (!metadata) return "-";
+
+      const numericValue =
+        metadata.semesterNumber !== null && metadata.semesterNumber !== undefined
+          ? Number(metadata.semesterNumber)
+          : Number.NaN;
+      const hasNumericSemester = !Number.isNaN(numericValue);
+
+      if (metadata.tahunAjaran && hasNumericSemester) {
+        return formatAcademicPeriod(metadata.tahunAjaran, numericValue);
+      }
+
+      return buildSemesterTitle(metadata);
+    },
+    [buildSemesterTitle]
+  );
+
+  return {
+    normalizeSemesterMetadata,
+    buildSemesterTitle,
+    buildSemesterDateRange,
+    formatStudyDays,
+    buildSemesterLabel,
+    getSemesterLabelById,
+    resolveSemesterMetadata,
+    getSemesterOptionLabel,
+    buildSemesterPeriodLabel,
+  };
+};

--- a/src/hooks/use-teacher-dashboard.ts
+++ b/src/hooks/use-teacher-dashboard.ts
@@ -6,8 +6,8 @@ import {
   useState,
 } from "react";
 import { useToast } from "@/hooks/use-toast";
+import { useDashboardSemester } from "@/hooks/use-dashboard-semester";
 import apiService from "@/services/apiService";
-import { formatAcademicPeriod } from "@/utils/helpers";
 
 type Identifier = string | number;
 type UnknownRecord = Record<string, unknown>;
@@ -219,6 +219,9 @@ export function useTeacherDashboard(currentUser: TeacherDashboardUser | null) {
   const [classes, setClasses] = useState<ClassInfo[]>([]);
   const [semesters, setSemesters] = useState<Semester[]>([]);
   const [selectedSemesterId, setSelectedSemesterId] = useState<string>("");
+  const { buildSemesterLabel, getSemesterLabelById } = useDashboardSemester({
+    semesters,
+  });
   const [showGradeDialog, setShowGradeDialog] = useState(false);
   const [showAttendanceDialog, setShowAttendanceDialog] = useState(false);
   const [showStudentListDialog, setShowStudentListDialog] = useState(false);
@@ -335,53 +338,6 @@ export function useTeacherDashboard(currentUser: TeacherDashboardUser | null) {
       return semesters.find((semester) => String(semester.id) === String(id));
     },
     [semesters]
-  );
-
-  const buildSemesterLabel = useCallback((semesterItem: Semester | null) => {
-    if (!semesterItem) return null;
-    if (semesterItem.label) return semesterItem.label;
-
-    const tahunAjaran =
-      semesterItem.tahunAjaran ||
-      semesterItem.tahun ||
-      semesterItem.academicYear ||
-      semesterItem.year ||
-      null;
-    const semesterNumber =
-      semesterItem.semester ??
-      semesterItem.semesterNumber ??
-      semesterItem.term ??
-      null;
-
-    if (
-      !tahunAjaran &&
-      (semesterNumber === null || semesterNumber === undefined)
-    ) {
-      return null;
-    }
-
-    const parsedSemester =
-      semesterNumber === null || semesterNumber === undefined
-        ? null
-        : Number(semesterNumber);
-    const normalizedSemester =
-      parsedSemester !== null && !Number.isNaN(parsedSemester)
-        ? parsedSemester
-        : semesterNumber;
-
-    return formatAcademicPeriod(tahunAjaran, normalizedSemester);
-  }, []);
-
-  const getSemesterLabelById = useCallback(
-    (id: Identifier | null, fallback?: Semester | null) => {
-      const semesterRecord = getSemesterRecordById(id);
-      return (
-        buildSemesterLabel(semesterRecord) ||
-        buildSemesterLabel(fallback) ||
-        "-"
-      );
-    },
-    [buildSemesterLabel, getSemesterRecordById]
   );
 
   const resolveSemesterDetails = useCallback(
@@ -1157,8 +1113,6 @@ export function useTeacherDashboard(currentUser: TeacherDashboardUser | null) {
     selectedSubjectKelasId,
     selectedSubjectForGrades,
     selectedSubjectForAttendance,
-    buildSemesterLabel,
-    getSemesterLabelById,
   };
 }
 

--- a/src/pages/guru/Dashboard.tsx
+++ b/src/pages/guru/Dashboard.tsx
@@ -7,6 +7,7 @@ import { TeacherGradeTableDialog } from "@/components/guru/TeacherGradeTableDial
 import { TeacherAttendanceTableDialog } from "@/components/guru/TeacherAttendanceTableDialog";
 import { TeacherStudentListDialog } from "@/components/guru/TeacherStudentListDialog";
 import { TeacherDashboardTabs } from "@/components/guru/TeacherDashboardTabs";
+import { useDashboardSemester } from "@/hooks/use-dashboard-semester";
 import {
   type TeacherDashboardUser,
   useTeacherDashboard,
@@ -26,9 +27,11 @@ const TeacherDashboard = ({ currentUser, onLogout }: TeacherDashboardProps) => {
     selectedSemesterId,
     setSelectedSemesterId,
     semesters,
-    buildSemesterLabel,
-    getSemesterLabelById,
   } = dashboard;
+
+  const { buildSemesterLabel, getSemesterLabelById } = useDashboardSemester({
+    semesters,
+  });
 
   return (
     <div className="min-h-screen bg-background">
@@ -44,8 +47,16 @@ const TeacherDashboard = ({ currentUser, onLogout }: TeacherDashboardProps) => {
         />
 
         <div className="flex flex-wrap gap-4 mb-8">
-          <TeacherGradeDialog dashboard={dashboard} />
-          <TeacherAttendanceDialog dashboard={dashboard} />
+          <TeacherGradeDialog
+            dashboard={dashboard}
+            buildSemesterLabel={buildSemesterLabel}
+            getSemesterLabelById={getSemesterLabelById}
+          />
+          <TeacherAttendanceDialog
+            dashboard={dashboard}
+            buildSemesterLabel={buildSemesterLabel}
+            getSemesterLabelById={getSemesterLabelById}
+          />
         </div>
 
         <TeacherGradeTableDialog dashboard={dashboard} />

--- a/src/pages/siswa/Dashboard.tsx
+++ b/src/pages/siswa/Dashboard.tsx
@@ -15,6 +15,7 @@ import {
   StudentGradesTable,
   StudentStatsCards,
 } from "@/components/siswa";
+import { useDashboardSemester } from "@/hooks/use-dashboard-semester";
 import { StudentUser, useStudentDashboard } from "@/hooks/use-student-dashboard";
 import { calculateAverage, formatDate, getGradeColor } from "@/utils/helpers";
 
@@ -30,10 +31,6 @@ const StudentDashboard = ({ currentUser, onLogout }: StudentDashboardProps) => {
     attendance,
     attendanceStats,
     averageGrade,
-    buildSemesterDateRange,
-    buildSemesterTitle,
-    formatStudyDays,
-    getSemesterMetadata,
     grades,
     handlePrintReport,
     handleSemesterChange,
@@ -44,6 +41,13 @@ const StudentDashboard = ({ currentUser, onLogout }: StudentDashboardProps) => {
     semesters,
     subjectGrades,
   } = useStudentDashboard({ currentUser });
+
+  const {
+    normalizeSemesterMetadata,
+    buildSemesterTitle,
+    buildSemesterDateRange,
+    formatStudyDays,
+  } = useDashboardSemester({ semesters });
 
   const semesterTitle = buildSemesterTitle(selectedSemesterMetadata);
   const semesterDateRange = buildSemesterDateRange(selectedSemesterMetadata);
@@ -86,7 +90,7 @@ const StudentDashboard = ({ currentUser, onLogout }: StudentDashboardProps) => {
                 <SelectContent>
                   {semesters.length > 0 ? (
                     semesters.map((semester) => {
-                      const metadata = getSemesterMetadata(semester);
+                      const metadata = normalizeSemesterMetadata(semester);
                       return (
                         <SelectItem
                           key={semester.id}

--- a/src/pages/walikelas/Dashboard.tsx
+++ b/src/pages/walikelas/Dashboard.tsx
@@ -19,6 +19,7 @@ import StudentsSection from "@/components/walikelas/StudentsSection";
 import GradesSection from "@/components/walikelas/GradesSection";
 import AttendanceSection from "@/components/walikelas/AttendanceSection";
 import ReportsSection from "@/components/walikelas/ReportsSection";
+import { useDashboardSemester } from "@/hooks/use-dashboard-semester";
 import useWalikelasDashboard from "@/hooks/use-walikelas-dashboard";
 
 const WalikelasaDashboard = ({ currentUser, onLogout }) => {
@@ -35,10 +36,7 @@ const WalikelasaDashboard = ({ currentUser, onLogout }) => {
     semesters,
     selectedSemesterId,
     handleSemesterChange,
-    getSemesterOptionLabel,
     selectedSemesterMetadata,
-    selectedSemesterPeriodLabel,
-    selectedSemesterDateRange,
     showStudentDialog,
     handleStudentDialogChange,
     startAddStudent,
@@ -57,6 +55,19 @@ const WalikelasaDashboard = ({ currentUser, onLogout }) => {
     resetStudentForm,
     editStudent,
   } = useWalikelasDashboard(currentUser);
+
+  const {
+    getSemesterOptionLabel,
+    buildSemesterPeriodLabel,
+    buildSemesterDateRange,
+  } = useDashboardSemester({ semesters });
+
+  const selectedSemesterPeriodLabel = buildSemesterPeriodLabel(
+    selectedSemesterMetadata
+  );
+  const selectedSemesterDateRange = buildSemesterDateRange(
+    selectedSemesterMetadata
+  );
 
   return (
     <div className="min-h-screen bg-background">


### PR DESCRIPTION
## Summary
- extract shared semester normalization and labeling logic into a new `useDashboardSemester` hook
- update student, teacher, and wali kelas dashboards to consume the shared hook instead of duplicating helpers
- adjust teacher dashboard dialogs to accept semester helper functions via props

## Testing
- Not run (environment missing vitest binary)


------
https://chatgpt.com/codex/tasks/task_e_68f619b7278c833291b94ecf3240dd3f