### PR TITLE
Handle active semester enforcement errors

### DIFF
--- a/src/hooks/use-teacher-dashboard.ts
+++ b/src/hooks/use-teacher-dashboard.ts
@@ -503,12 +503,24 @@ export function useTeacherDashboard(currentUser: TeacherDashboardUser | null) {
         setGrades(gradesWithNames);
       } catch (error: unknown) {
         console.error("Error loading grades:", error);
+        const { code, message } = (error as { code?: string; message?: string }) ?? {};
+        let description = message || "Gagal memuat data nilai";
+
+        if (code === "SEMESTER_NOT_ACTIVE") {
+          description =
+            "Semester yang dipilih belum aktif. Silakan pilih semester aktif untuk melihat data nilai.";
+          setGrades([]);
+        } else if (code === "ACTIVE_SEMESTER_NOT_FOUND") {
+          description =
+            "Belum ada semester aktif yang ditetapkan. Pilih semester aktif sebelum melihat data nilai.";
+          setGrades([]);
+        } else if (code === "SEMESTER_NOT_FOUND") {
+          description = "Semester tidak ditemukan. Silakan pilih semester lain.";
+        }
+
         toast({
           title: "Error",
-          description:
-            error?.code === "SEMESTER_NOT_FOUND"
-              ? "Semester tidak ditemukan. Silakan pilih semester lain."
-              : error?.message || "Gagal memuat data nilai",
+          description,
           variant: "destructive",
         });
       }
@@ -579,12 +591,24 @@ export function useTeacherDashboard(currentUser: TeacherDashboardUser | null) {
         setAttendance(attendanceWithNames);
       } catch (error: unknown) {
         console.error("Error loading attendance:", error);
+        const { code, message } = (error as { code?: string; message?: string }) ?? {};
+        let description = message || "Gagal memuat data kehadiran";
+
+        if (code === "SEMESTER_NOT_ACTIVE") {
+          description =
+            "Semester yang dipilih belum aktif. Silakan pilih semester aktif untuk melihat data kehadiran.";
+          setAttendance([]);
+        } else if (code === "ACTIVE_SEMESTER_NOT_FOUND") {
+          description =
+            "Belum ada semester aktif yang ditetapkan. Pilih semester aktif sebelum melihat data kehadiran.";
+          setAttendance([]);
+        } else if (code === "SEMESTER_NOT_FOUND") {
+          description = "Semester tidak ditemukan. Silakan pilih semester lain.";
+        }
+
         toast({
           title: "Error",
-          description:
-            error?.code === "SEMESTER_NOT_FOUND"
-              ? "Semester tidak ditemukan. Silakan pilih semester lain."
-              : error?.message || "Gagal memuat data kehadiran",
+          description,
           variant: "destructive",
         });
       }
@@ -759,19 +783,63 @@ export function useTeacherDashboard(currentUser: TeacherDashboardUser | null) {
           handleGradeDialogOpenChange(false);
           await loadGradesData();
         } else {
-          toast({
-            title: "Error",
-            description:
-              isRecord(result) && typeof result.message === "string"
-                ? result.message
-                : "Gagal menyimpan nilai",
-            variant: "destructive",
-          });
+          const resultCode =
+            isRecord(result) && typeof result.code === "string"
+              ? (result.code as string)
+              : undefined;
+          if (resultCode === "SEMESTER_NOT_ACTIVE") {
+            toast({
+              title: "Penegakan semester aktif",
+              description:
+                "Pengunggahan nilai diblokir karena semester yang dipilih belum aktif. Gunakan semester aktif sebelum menyimpan nilai.",
+              variant: "destructive",
+            });
+            handleGradeDialogOpenChange(false);
+          } else if (resultCode === "ACTIVE_SEMESTER_NOT_FOUND") {
+            toast({
+              title: "Penegakan semester aktif",
+              description:
+                "Belum ada semester aktif yang ditetapkan. Tetapkan semester aktif terlebih dahulu sebelum menambahkan nilai.",
+              variant: "destructive",
+            });
+            handleGradeDialogOpenChange(false);
+          } else {
+            toast({
+              title: "Error",
+              description:
+                isRecord(result) && typeof result.message === "string"
+                  ? result.message
+                  : "Gagal menyimpan nilai",
+              variant: "destructive",
+            });
+          }
         }
       } catch (error) {
+        const { code, message } = (error as { code?: string; message?: string }) ?? {};
+        if (code === "SEMESTER_NOT_ACTIVE") {
+          toast({
+            title: "Penegakan semester aktif",
+            description:
+              "Pengunggahan nilai diblokir karena semester yang dipilih belum aktif. Gunakan semester aktif sebelum menyimpan nilai.",
+            variant: "destructive",
+          });
+          handleGradeDialogOpenChange(false);
+          return;
+        }
+        if (code === "ACTIVE_SEMESTER_NOT_FOUND") {
+          toast({
+            title: "Penegakan semester aktif",
+            description:
+              "Belum ada semester aktif yang ditetapkan. Tetapkan semester aktif terlebih dahulu sebelum menambahkan nilai.",
+            variant: "destructive",
+          });
+          handleGradeDialogOpenChange(false);
+          return;
+        }
+
         toast({
           title: "Error",
-          description: "Gagal menyimpan nilai",
+          description: message || "Gagal menyimpan nilai",
           variant: "destructive",
         });
       }
@@ -879,19 +947,63 @@ export function useTeacherDashboard(currentUser: TeacherDashboardUser | null) {
           handleAttendanceDialogOpenChange(false);
           await loadAttendanceData();
         } else {
-          toast({
-            title: "Error",
-            description:
-              isRecord(result) && typeof result.message === "string"
-                ? result.message
-                : "Gagal menyimpan kehadiran",
-            variant: "destructive",
-          });
+          const resultCode =
+            isRecord(result) && typeof result.code === "string"
+              ? (result.code as string)
+              : undefined;
+          if (resultCode === "SEMESTER_NOT_ACTIVE") {
+            toast({
+              title: "Penegakan semester aktif",
+              description:
+                "Pengunggahan kehadiran diblokir karena semester yang dipilih belum aktif. Gunakan semester aktif sebelum menyimpan data.",
+              variant: "destructive",
+            });
+            handleAttendanceDialogOpenChange(false);
+          } else if (resultCode === "ACTIVE_SEMESTER_NOT_FOUND") {
+            toast({
+              title: "Penegakan semester aktif",
+              description:
+                "Belum ada semester aktif yang ditetapkan. Tetapkan semester aktif terlebih dahulu sebelum menambahkan data kehadiran.",
+              variant: "destructive",
+            });
+            handleAttendanceDialogOpenChange(false);
+          } else {
+            toast({
+              title: "Error",
+              description:
+                isRecord(result) && typeof result.message === "string"
+                  ? result.message
+                  : "Gagal menyimpan kehadiran",
+              variant: "destructive",
+            });
+          }
         }
       } catch (error) {
+        const { code, message } = (error as { code?: string; message?: string }) ?? {};
+        if (code === "SEMESTER_NOT_ACTIVE") {
+          toast({
+            title: "Penegakan semester aktif",
+            description:
+              "Pengunggahan kehadiran diblokir karena semester yang dipilih belum aktif. Gunakan semester aktif sebelum menyimpan data.",
+            variant: "destructive",
+          });
+          handleAttendanceDialogOpenChange(false);
+          return;
+        }
+        if (code === "ACTIVE_SEMESTER_NOT_FOUND") {
+          toast({
+            title: "Penegakan semester aktif",
+            description:
+              "Belum ada semester aktif yang ditetapkan. Tetapkan semester aktif terlebih dahulu sebelum menambahkan data kehadiran.",
+            variant: "destructive",
+          });
+          handleAttendanceDialogOpenChange(false);
+          return;
+        }
+
         toast({
           title: "Error",
-          description: "Gagal menyimpan kehadiran",
+          description: message || "Gagal menyimpan kehadiran",
           variant: "destructive",
         });
       }

--- a/src/hooks/use-walikelas-dashboard.ts
+++ b/src/hooks/use-walikelas-dashboard.ts
@@ -228,20 +228,32 @@ const useWalikelasDashboard = (currentUser: CurrentUser | null) => {
         setAttendance(attendanceWithMetadata);
       } catch (error: any) {
         console.error("Failed to load walikelas data", error);
+        const errorCode = typeof error?.code === "string" ? error.code : "";
         const isSemesterNotFound =
-          error?.code === "SEMESTER_NOT_FOUND" ||
+          errorCode === "SEMESTER_NOT_FOUND" ||
           (typeof error?.message === "string" &&
             error.message.toLowerCase().includes("semester tidak ditemukan"));
 
+        const description = (() => {
+          if (errorCode === "SEMESTER_NOT_ACTIVE") {
+            return "Semester yang dipilih belum aktif. Silakan gunakan semester aktif agar data wali kelas dapat ditampilkan.";
+          }
+          if (errorCode === "ACTIVE_SEMESTER_NOT_FOUND") {
+            return "Belum ada semester aktif yang ditetapkan. Pilih atau tetapkan semester aktif untuk melihat data wali kelas.";
+          }
+          if (isSemesterNotFound) {
+            return "Semester tidak ditemukan. Silakan pilih semester lain.";
+          }
+          return error?.message || "Gagal memuat data wali kelas";
+        })();
+
         toast({
           title: "Error",
-          description: isSemesterNotFound
-            ? "Semester tidak ditemukan. Silakan pilih semester lain."
-            : error?.message || "Gagal memuat data wali kelas",
+          description,
           variant: "destructive",
         });
 
-        if (isSemesterNotFound) {
+        if (isSemesterNotFound || errorCode === "SEMESTER_NOT_ACTIVE" || errorCode === "ACTIVE_SEMESTER_NOT_FOUND") {
           setGrades([]);
           setAttendance([]);
         }


### PR DESCRIPTION
## Summary
- update student, teacher, and walikelas dashboards to surface helpful messages for new semester enforcement errors and clear stale data
- ensure teacher-grade and attendance dialogs close when submissions are blocked by active-semester enforcement and explain the reason
- add unit coverage for student dashboard messaging when semesters are inactive or missing and expose semester metadata helpers

## Testing
- npm test -- run

------
https://chatgpt.com/codex/tasks/task_e_68f6239d1524833285360005f1cb72c5