### PR TITLE
Fix attendance percentage using study days

### DIFF
--- a/src/components/student/AttendanceView.tsx
+++ b/src/components/student/AttendanceView.tsx
@@ -9,7 +9,13 @@ interface AttendanceViewProps {
 }
 
 export default function AttendanceView({ attendance, loading }: AttendanceViewProps) {
-  const attendanceStats = calculateAttendanceStats(attendance);
+  const derivedSemesterInfo = Array.isArray(attendance)
+    ? attendance.find((record) => record?.semesterInfo)?.semesterInfo ?? null
+    : null;
+
+  const attendanceStats = calculateAttendanceStats(attendance, {
+    semesterInfo: derivedSemesterInfo,
+  });
 
   return (
     <Card className="shadow-soft">


### PR DESCRIPTION
## Summary
- update attendance statistics helper to consider semester study days when computing percentages
- ensure student dashboard waits for enforcement settings and forwards semester metadata to attendance stats
- derive semester metadata for attendance views and refine relaxed-mode warning copy

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68f6f7ef70c883329b315c0453aa500f