### PR TITLE
Fix empty SelectItem value in teacher semester selector

### DIFF
--- a/src/components/guru/TeacherSemesterSelector.tsx
+++ b/src/components/guru/TeacherSemesterSelector.tsx
@@ -48,7 +48,7 @@ export function TeacherSemesterSelector({
                 </SelectItem>
               ))
             ) : (
-              <SelectItem value="" disabled>
+              <SelectItem value="no-semesters" disabled>
                 Data semester belum tersedia
               </SelectItem>
             )}


### PR DESCRIPTION
## Summary
- update the disabled SelectItem placeholder in the teacher semester selector to use a non-empty value
- prevent runtime error from Select requiring non-empty value props

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f70bb5b57c8332982322ff98fe0823