### PR TITLE
Add study day context to teacher attendance and grades

### DIFF
--- a/src/components/guru/TeacherAttendanceTableDialog.tsx
+++ b/src/components/guru/TeacherAttendanceTableDialog.tsx
@@ -55,6 +55,7 @@ export function TeacherAttendanceTableDialog({
                 <TableHead>NISN</TableHead>
                 <TableHead>Status Kehadiran</TableHead>
                 <TableHead>Tanggal</TableHead>
+                <TableHead>Hari Ke-</TableHead>
                 <TableHead>Semester</TableHead>
                 <TableHead>Keterangan</TableHead>
                 <TableHead>Aksi</TableHead>
@@ -100,6 +101,11 @@ export function TeacherAttendanceTableDialog({
                       </TableCell>
                       <TableCell className="text-muted-foreground">
                         {formatDate(att.tanggal)}
+                      </TableCell>
+                      <TableCell>
+                        {att.studyDayNumber != null
+                          ? `Hari ke-${att.studyDayNumber}`
+                          : "-"}
                       </TableCell>
                       <TableCell>{att.semesterLabel || "-"}</TableCell>
                       <TableCell className="text-muted-foreground">

--- a/src/components/guru/TeacherDashboardTabs.tsx
+++ b/src/components/guru/TeacherDashboardTabs.tsx
@@ -156,6 +156,11 @@ export function TeacherDashboardTabs({
                               >
                                 <span className="text-sm">{grade.studentName}</span>
                                 <div className="flex items-center justify-end gap-2 flex-wrap">
+                                  {grade.studyDayNumber != null && (
+                                    <Badge variant="outline" className="text-xs">
+                                      Hari ke-{grade.studyDayNumber}
+                                    </Badge>
+                                  )}
                                   {grade.semesterLabel && (
                                     <Badge variant="outline" className="text-xs">
                                       {grade.semesterLabel}
@@ -214,6 +219,11 @@ export function TeacherDashboardTabs({
                               >
                                 <span className="text-sm">{att.studentName}</span>
                                 <div className="flex items-center justify-end gap-2 flex-wrap">
+                                  {att.studyDayNumber != null && (
+                                    <Badge variant="outline" className="text-xs">
+                                      Hari ke-{att.studyDayNumber}
+                                    </Badge>
+                                  )}
                                   {att.semesterLabel && (
                                     <Badge variant="outline" className="text-xs">
                                       {att.semesterLabel}

--- a/src/components/guru/TeacherGradeTableDialog.tsx
+++ b/src/components/guru/TeacherGradeTableDialog.tsx
@@ -52,6 +52,7 @@ export function TeacherGradeTableDialog({
                 <TableHead>Jenis Penilaian</TableHead>
                 <TableHead>Nilai</TableHead>
                 <TableHead>Tanggal</TableHead>
+                <TableHead>Hari Ke-</TableHead>
                 <TableHead>Semester</TableHead>
                 <TableHead>Status</TableHead>
                 <TableHead>Aksi</TableHead>
@@ -85,6 +86,11 @@ export function TeacherGradeTableDialog({
                       </TableCell>
                       <TableCell className="text-muted-foreground">
                         {formatDate(grade.tanggal)}
+                      </TableCell>
+                      <TableCell>
+                        {grade.studyDayNumber != null
+                          ? `Hari ke-${grade.studyDayNumber}`
+                          : "-"}
                       </TableCell>
                       <TableCell>{grade.semesterLabel || "-"}</TableCell>
                       <TableCell>

--- a/src/hooks/use-teacher-dashboard.ts
+++ b/src/hooks/use-teacher-dashboard.ts
@@ -10,6 +10,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useDashboardSemester } from "@/hooks/use-dashboard-semester";
 import { useSemesterEnforcement } from "@/hooks/use-semester-enforcement";
 import apiService from "@/services/apiService";
+import { getStudyDayNumber } from "@/utils/helpers";
 
 type Identifier = string | number;
 type UnknownRecord = Record<string, unknown>;
@@ -69,6 +70,7 @@ export type GradeRecord = UnknownRecord & {
   semester?: number;
   studentName?: string;
   semesterLabel?: string;
+  studyDayNumber?: number | null;
 };
 
 export type AttendanceRecord = UnknownRecord & {
@@ -87,6 +89,7 @@ export type AttendanceRecord = UnknownRecord & {
   studentName?: string;
   semesterLabel?: string;
   keterangan?: string;
+  studyDayNumber?: number | null;
 };
 
 type GradeFormState = {
@@ -560,6 +563,10 @@ export function useTeacherDashboard(currentUser: TeacherDashboardUser | null) {
             grade.semesterId,
             grade.semesterInfo
           );
+          const semesterMetadata = resolveSemesterMetadata(
+            grade.semesterId ?? null,
+            semesterDetails || grade.semesterInfo
+          );
           const semesterLabel = getSemesterLabelById(
             grade.semesterId,
             semesterDetails || grade.semesterInfo
@@ -572,6 +579,10 @@ export function useTeacherDashboard(currentUser: TeacherDashboardUser | null) {
             null;
           const semesterNumberValue =
             semesterDetails?.semester ?? grade.semester ?? null;
+          const studyDayNumber = getStudyDayNumber(grade.tanggal, {
+            semesterMetadata,
+            semesterInfo: semesterDetails || grade.semesterInfo,
+          });
           return {
             ...grade,
             studentName: student?.nama || "Unknown Student",
@@ -581,6 +592,7 @@ export function useTeacherDashboard(currentUser: TeacherDashboardUser | null) {
               semesterNumberValue === undefined || semesterNumberValue === null
                 ? grade.semester
                 : semesterNumberValue,
+            studyDayNumber,
           };
         });
 
@@ -715,6 +727,10 @@ export function useTeacherDashboard(currentUser: TeacherDashboardUser | null) {
             att.semesterId,
             att.semesterInfo
           );
+          const semesterMetadata = resolveSemesterMetadata(
+            att.semesterId ?? null,
+            semesterDetails || att.semesterInfo
+          );
           const semesterLabel = getSemesterLabelById(
             att.semesterId,
             semesterDetails || att.semesterInfo
@@ -727,6 +743,10 @@ export function useTeacherDashboard(currentUser: TeacherDashboardUser | null) {
             null;
           const semesterNumberValue =
             semesterDetails?.semester ?? att.semester ?? null;
+          const studyDayNumber = getStudyDayNumber(att.tanggal, {
+            semesterMetadata,
+            semesterInfo: semesterDetails || att.semesterInfo,
+          });
           return {
             ...att,
             studentName: student?.nama || "Unknown Student",
@@ -736,6 +756,7 @@ export function useTeacherDashboard(currentUser: TeacherDashboardUser | null) {
               semesterNumberValue === undefined || semesterNumberValue === null
                 ? att.semester
                 : semesterNumberValue,
+            studyDayNumber,
           };
         });
 


### PR DESCRIPTION
## Summary
- add a helper to derive the active study day from semester metadata and record dates
- surface the calculated "Hari ke" information in teacher grade and attendance tables and previews

## Testing
- npm run lint *(fails: existing @typescript-eslint/no-explicit-any violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68f70d5eab988332ad5847a31875c501