### PR TITLE
Refine teacher dashboard subject cards

### DIFF
--- a/src/components/guru/TeacherDashboardTabs.tsx
+++ b/src/components/guru/TeacherDashboardTabs.tsx
@@ -5,17 +5,29 @@ import {
   TabsList,
   TabsTrigger,
 } from "@/components/ui/tabs";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
   CardHeader,
   CardTitle,
 } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Badge } from "@/components/ui/badge";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  Accordion,
+  AccordionContent,
+  AccordionItem,
+  AccordionTrigger,
+} from "@/components/ui/accordion";
 
 import { UseTeacherDashboardReturn } from "@/hooks/use-teacher-dashboard";
-import { getGradeColor } from "@/utils/helpers";
 
 type TeacherDashboardTabsProps = {
   dashboard: UseTeacherDashboardReturn;
@@ -58,7 +70,7 @@ export function TeacherDashboardTabs({
         {loading ? (
           <div className="text-center">Loading...</div>
         ) : subjects.length > 0 ? (
-          <div className="grid gap-6">
+          <Accordion type="single" collapsible className="space-y-4">
             {subjects.map((subject) => {
               const subjectGrades = grades.filter(
                 (grade) =>
@@ -68,209 +80,203 @@ export function TeacherDashboardTabs({
                 (att) => att.subjectId === subject.id && att.kelasId === subject.kelasId
               );
 
-              return (
-                <Card key={subject.id} className="shadow-soft">
-                  <CardHeader>
-                    <div className="flex flex-col md:flex-row justify-between items-start md:items-center space-y-4 md:space-y-0">
-                      <div>
-                        <CardTitle className="flex items-center space-x-2">
-                          <BookOpen className="h-5 w-5 text-primary" />
-                          <span>
-                            {getSubjectName(subject.id)} Kelas {" "}
-                            {getClassesName(subject.kelasId)}
-                          </span>
-                        </CardTitle>
-                        <p className="text-muted-foreground">
-                          Nilai: {subjectGrades.length} | Kehadiran: {subjectAttendance.length}
-                        </p>
-                      </div>
+              const getAttendanceStatusLabel = (status: string) => {
+                if (status === "hadir") return "Hadir";
+                if (status === "sakit") return "Sakit";
+                if (status === "izin") return "Izin";
+                return "Alfa";
+              };
 
-                      <div className="flex flex-wrap gap-2">
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => handleViewStudentList(subject.id, subject.kelasId)}
-                        >
-                          <Users className="h-4 w-4 mr-2" />
-                          Lihat Siswa
-                        </Button>
-                        <Button
-                          size="sm"
-                          onClick={() => {
-                            setGradeForm((prev) => ({
-                              ...prev,
-                              subjectId: String(subject.id),
-                            }));
-                            setShowGradeDialog(true);
-                          }}
-                        >
-                          <Plus className="h-4 w-4 mr-2" />
-                          Input Nilai
-                        </Button>
-                        <Button
-                          size="sm"
-                          variant="outline"
-                          onClick={() => {
-                            setAttendanceForm((prev) => ({
-                              ...prev,
-                              subjectId: String(subject.id),
-                              kelasId: subject.kelasId
-                                ? String(subject.kelasId)
-                                : "",
-                            }));
-                            setShowAttendanceDialog(true);
-                          }}
-                        >
-                          <Calendar className="h-4 w-4 mr-2" />
-                          Input Kehadiran
-                        </Button>
-                      </div>
+              return (
+                <AccordionItem
+                  key={subject.id}
+                  value={`${subject.id}-${subject.kelasId}`}
+                  className="rounded-xl border border-border bg-card shadow-soft"
+                >
+                  <div className="px-4 pt-4">
+                    <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
+                      <AccordionTrigger className="flex-1 gap-4 rounded-lg bg-transparent px-0 py-0 text-left hover:no-underline">
+                        <div className="flex flex-col">
+                          <span className="flex items-center gap-2 text-base font-semibold text-foreground">
+                            <BookOpen className="h-5 w-5 text-primary" />
+                            {getSubjectName(subject.id)} Kelas {getClassesName(subject.kelasId)}
+                          </span>
+                          <span className="text-sm text-muted-foreground">
+                            {subjectGrades.length} nilai tercatat • {subjectAttendance.length} data kehadiran
+                          </span>
+                        </div>
+                      </AccordionTrigger>
+                      <DropdownMenu>
+                        <DropdownMenuTrigger asChild>
+                          <Button size="sm" className="shrink-0 gap-2">
+                            <Plus className="h-4 w-4" />
+                            Tambah data
+                          </Button>
+                        </DropdownMenuTrigger>
+                        <DropdownMenuContent align="end" className="w-56">
+                          <DropdownMenuLabel>Tambah informasi</DropdownMenuLabel>
+                          <DropdownMenuSeparator />
+                          <DropdownMenuItem
+                            onSelect={() => {
+                              setGradeForm((prev) => ({
+                                ...prev,
+                                subjectId: String(subject.id),
+                              }));
+                              setShowGradeDialog(true);
+                            }}
+                            className="gap-2"
+                          >
+                            <FileText className="h-4 w-4" /> Input nilai siswa
+                          </DropdownMenuItem>
+                          <DropdownMenuItem
+                            onSelect={() => {
+                              setAttendanceForm((prev) => ({
+                                ...prev,
+                                subjectId: String(subject.id),
+                                kelasId: subject.kelasId ? String(subject.kelasId) : "",
+                              }));
+                              setShowAttendanceDialog(true);
+                            }}
+                            className="gap-2"
+                          >
+                            <Calendar className="h-4 w-4" /> Catat kehadiran
+                          </DropdownMenuItem>
+                        </DropdownMenuContent>
+                      </DropdownMenu>
                     </div>
-                  </CardHeader>
-                  <CardContent>
-                    <div className="grid md:grid-cols-2 gap-6">
-                      <div>
-                        <div className="flex items-center justify-between mb-3">
-                          <h4 className="font-semibold flex items-center">
-                            <FileText className="h-4 w-4 mr-2" />
-                            Nilai Terkini ({subjectGrades.length})
-                          </h4>
-                          {subjectGrades.length > 0 && (
+                  </div>
+                  <AccordionContent className="px-4 pb-4">
+                    <div className="space-y-6">
+                      <div className="space-y-3 rounded-lg border border-dashed border-border/70 bg-muted/10 p-4">
+                        <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+                          <FileText className="h-4 w-4" /> Ringkasan nilai terbaru
+                        </div>
+                        {subjectGrades.length > 0 ? (
+                          <ul className="space-y-3 text-sm">
+                            {subjectGrades.slice(-3).map((grade) => (
+                              <li
+                                key={grade.id}
+                                className="rounded-md border border-border/60 bg-background px-3 py-2 shadow-sm"
+                              >
+                                <p className="font-medium text-foreground">
+                                  {grade.studentName}
+                                </p>
+                                <p className="text-muted-foreground">
+                                  Nilai terakhir: {grade.nilai}
+                                  {grade.jenis ? ` untuk ${grade.jenis}` : ""}
+                                  {grade.semesterLabel ? ` • ${grade.semesterLabel}` : ""}
+                                  {grade.studyDayNumber != null
+                                    ? ` • Hari ke-${grade.studyDayNumber}`
+                                    : ""}
+                                </p>
+                              </li>
+                            ))}
+                            {subjectGrades.length > 3 && (
+                              <li className="text-center text-xs text-muted-foreground">
+                                +{subjectGrades.length - 3} catatan nilai lainnya
+                              </li>
+                            )}
+                          </ul>
+                        ) : (
+                          <div className="text-center text-sm text-muted-foreground">
+                            <p>Belum ada nilai yang dicatat untuk mata pelajaran ini.</p>
+                          </div>
+                        )}
+                        {subjectGrades.length > 0 && (
+                          <div className="flex flex-wrap items-center justify-between gap-2 text-sm">
+                            <p className="text-muted-foreground">
+                              Butuh melihat riwayat lengkap nilai siswa?
+                            </p>
                             <Button
-                              size="sm"
-                              variant="outline"
+                              variant="link"
+                              className="px-0"
                               onClick={() =>
                                 handleViewAllGrades(subject.id, subject.kelasId)
                               }
                             >
-                              Lihat Semua
+                              Lihat semua nilai
                             </Button>
-                          )}
-                        </div>
-                        {subjectGrades.length > 0 ? (
-                          <div className="space-y-2">
-                            {subjectGrades.slice(-3).map((grade) => (
-                              <div
-                                key={grade.id}
-                                className="flex justify-between items-center p-2 bg-muted/20 rounded"
-                              >
-                                <span className="text-sm">{grade.studentName}</span>
-                                <div className="flex items-center justify-end gap-2 flex-wrap">
-                                  {grade.studyDayNumber != null && (
-                                    <Badge variant="outline" className="text-xs">
-                                      Hari ke-{grade.studyDayNumber}
-                                    </Badge>
-                                  )}
-                                  {grade.semesterLabel && (
-                                    <Badge variant="outline" className="text-xs">
-                                      {grade.semesterLabel}
-                                    </Badge>
-                                  )}
-                                  <Badge variant="outline" className="text-xs">
-                                    {grade.jenis}
-                                  </Badge>
-                                  <Badge
-                                    variant="outline"
-                                    className={`text-xs ${getGradeColor(grade.nilai)}`}
-                                  >
-                                    {grade.nilai}
-                                  </Badge>
-                                </div>
-                              </div>
-                            ))}
-                            {subjectGrades.length > 3 && (
-                              <p className="text-xs text-muted-foreground text-center">
-                                +{subjectGrades.length - 3} nilai lainnya
-                              </p>
-                            )}
-                          </div>
-                        ) : (
-                          <div className="text-center py-4 text-muted-foreground">
-                            <FileText className="h-8 w-8 mx-auto mb-2" />
-                            <p className="text-xs">Belum ada nilai</p>
                           </div>
                         )}
                       </div>
 
-                      <div>
-                        <div className="flex items-center justify-between mb-3">
-                          <h4 className="font-semibold flex items-center">
-                            <Calendar className="h-4 w-4 mr-2" />
-                            Kehadiran ({subjectAttendance.length})
-                          </h4>
-                          {subjectAttendance.length > 0 && (
+                      <div className="space-y-3 rounded-lg border border-dashed border-border/70 bg-muted/10 p-4">
+                        <div className="flex items-center gap-2 text-sm font-semibold text-foreground">
+                          <Calendar className="h-4 w-4" /> Ringkasan kehadiran siswa
+                        </div>
+                        {subjectAttendance.length > 0 ? (
+                          <ul className="space-y-3 text-sm">
+                            {subjectAttendance.slice(-3).map((att) => (
+                              <li
+                                key={att.id}
+                                className="rounded-md border border-border/60 bg-background px-3 py-2 shadow-sm"
+                              >
+                                <p className="font-medium text-foreground">
+                                  {att.studentName}
+                                </p>
+                                <p className="text-muted-foreground">
+                                  Status kehadiran: {getAttendanceStatusLabel(att.status)}
+                                  {att.studyDayNumber != null
+                                    ? ` • Hari ke-${att.studyDayNumber}`
+                                    : ""}
+                                  {att.semesterLabel ? ` • ${att.semesterLabel}` : ""}
+                                </p>
+                              </li>
+                            ))}
+                            {subjectAttendance.length > 3 && (
+                              <li className="text-center text-xs text-muted-foreground">
+                                +{subjectAttendance.length - 3} catatan kehadiran lainnya
+                              </li>
+                            )}
+                          </ul>
+                        ) : (
+                          <div className="text-center text-sm text-muted-foreground">
+                            <p>Belum ada catatan kehadiran yang masuk.</p>
+                          </div>
+                        )}
+                        {subjectAttendance.length > 0 && (
+                          <div className="flex flex-wrap items-center justify-between gap-2 text-sm">
+                            <p className="text-muted-foreground">
+                              Lihat daftar lengkap kehadiran untuk analisis detail.
+                            </p>
                             <Button
-                              size="sm"
-                              variant="outline"
+                              variant="link"
+                              className="px-0"
                               onClick={() =>
                                 handleViewAllAttendance(subject.id, subject.kelasId)
                               }
                             >
-                              Lihat Semua
+                              Lihat semua kehadiran
                             </Button>
-                          )}
-                        </div>
-                        {subjectAttendance.length > 0 ? (
-                          <div className="space-y-2">
-                            {subjectAttendance.slice(-3).map((att) => (
-                              <div
-                                key={att.id}
-                                className="flex justify-between items-center p-2 bg-muted/20 rounded"
-                              >
-                                <span className="text-sm">{att.studentName}</span>
-                                <div className="flex items-center justify-end gap-2 flex-wrap">
-                                  {att.studyDayNumber != null && (
-                                    <Badge variant="outline" className="text-xs">
-                                      Hari ke-{att.studyDayNumber}
-                                    </Badge>
-                                  )}
-                                  {att.semesterLabel && (
-                                    <Badge variant="outline" className="text-xs">
-                                      {att.semesterLabel}
-                                    </Badge>
-                                  )}
-                                  <Badge
-                                    variant="outline"
-                                    className={`text-xs ${
-                                      att.status === "hadir"
-                                        ? "bg-green-100 text-green-800"
-                                        : att.status === "sakit"
-                                        ? "bg-yellow-100 text-yellow-800"
-                                        : att.status === "izin"
-                                        ? "bg-blue-100 text-blue-800"
-                                        : "bg-red-100 text-red-800"
-                                    }`}
-                                  >
-                                    {att.status === "hadir"
-                                      ? "Hadir"
-                                      : att.status === "sakit"
-                                      ? "Sakit"
-                                      : att.status === "izin"
-                                      ? "Izin"
-                                      : "Alfa"}
-                                  </Badge>
-                                </div>
-                              </div>
-                            ))}
-                            {subjectAttendance.length > 3 && (
-                              <p className="text-xs text-muted-foreground text-center">
-                                +{subjectAttendance.length - 3} record lainnya
-                              </p>
-                            )}
-                          </div>
-                        ) : (
-                          <div className="text-center py-4 text-muted-foreground">
-                            <Calendar className="h-8 w-8 mx-auto mb-2" />
-                            <p className="text-xs">Belum ada kehadiran</p>
                           </div>
                         )}
                       </div>
+
+                      <div className="rounded-lg border border-border/70 bg-background px-4 py-3 shadow-sm">
+                        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                          <div>
+                            <p className="text-sm font-semibold text-foreground">
+                              Kelola daftar siswa
+                            </p>
+                            <p className="text-sm text-muted-foreground">
+                              Tinjau siswa yang terdaftar dalam mata pelajaran ini kapan saja.
+                            </p>
+                          </div>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => handleViewStudentList(subject.id, subject.kelasId)}
+                          >
+                            <Users className="mr-2 h-4 w-4" /> Lihat siswa
+                          </Button>
+                        </div>
+                      </div>
                     </div>
-                  </CardContent>
-                </Card>
+                  </AccordionContent>
+                </AccordionItem>
               );
             })}
-          </div>
+          </Accordion>
         ) : (
           <div className="text-center py-12">
             <BookOpen className="h-16 w-16 mx-auto mb-4 text-muted-foreground" />


### PR DESCRIPTION
## Summary
- rework teacher subject list into an accordion layout with a focused summary and primary "Tambah data" action
- move secondary actions into expanded sections with descriptive guidance for grades, attendance, and student lists
- replace badge clusters with readable bullet summaries for recent grades and attendance updates

## Testing
- `npm run lint` *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68f7128b680c83329d7c5c15911307a0