### PR TITLE
Refine teacher dialogs with guided steps

### DIFF
--- a/src/components/guru/TeacherAttendanceDialog.tsx
+++ b/src/components/guru/TeacherAttendanceDialog.tsx
@@ -9,6 +9,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
 import {
   Select,
   SelectContent,
@@ -50,7 +51,13 @@ export function TeacherAttendanceDialog({
     getStudentName,
     handleAddAttendance,
     editingAttendance,
+    attendanceContextLock,
   } = dashboard;
+
+  const isSubjectLocked =
+    !editingAttendance &&
+    !!attendanceContextLock?.subjectId &&
+    !!attendanceContextLock?.kelasId;
 
   return (
     <Dialog
@@ -69,169 +76,213 @@ export function TeacherAttendanceDialog({
             {editingAttendance ? "Edit Kehadiran Siswa" : "Input Kehadiran Siswa"}
           </DialogTitle>
         </DialogHeader>
-        <form onSubmit={handleAddAttendance} className="space-y-4">
-          <div className="space-y-2">
-            <Label>Mata Pelajaran</Label>
-            <Select
-              value={
-                attendanceForm.subjectId && attendanceForm.kelasId
-                  ? `${attendanceForm.subjectId}-${attendanceForm.kelasId}`
-                  : ""
-              }
-              onValueChange={(value) => {
-                const [subjectId, kelasId] = value.split("-");
-                setAttendanceForm((prev) => ({
-                  ...prev,
-                  subjectId,
-                  kelasId,
-                  studentId: "",
-                }));
-              }}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Pilih mata pelajaran">
-                  {attendanceForm.subjectId
-                    ? `${getSubjectName(attendanceForm.subjectId)} (${getClassesName(attendanceForm.kelasId)})`
-                    : "Pilih mata pelajaran"}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                {subjects.map((subject, idx) => (
-                  <SelectItem
-                    key={`${subject.id}-${subject.kelasId}-${idx}`}
-                    value={`${subject.id}-${subject.kelasId}`}
-                  >
-                    {subject.nama} ({getClassesName(subject.kelasId)})
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="space-y-2">
-            <Label>Siswa</Label>
-            <Select
-              value={attendanceForm.studentId}
-              onValueChange={(value) =>
-                setAttendanceForm((prev) => ({
-                  ...prev,
-                  studentId: value,
-                }))
-              }
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Pilih siswa">
-                  {getStudentName(attendanceForm.studentId)}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                {students
-                  .filter(
-                    (s) => String(s.kelasId) === String(attendanceForm.kelasId)
-                  )
-                  .map((student) => (
-                    <SelectItem key={student.id} value={String(student.id)}>
-                      {student.nama} ({student.nisn})
-                    </SelectItem>
-                  ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="space-y-2">
-            <Label>Semester</Label>
-            <Select
-              value={attendanceForm.semesterId || ""}
-              onValueChange={(value) =>
-                setAttendanceForm((prev) => ({
-                  ...prev,
-                  semesterId: value,
-                }))
-              }
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Pilih semester">
-                  {attendanceForm.semesterId
-                    ? getSemesterLabelById(attendanceForm.semesterId)
-                    : semesters.length > 0
-                    ? "Pilih semester"
-                    : "Semester belum tersedia"}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                {semesters.length > 0 ? (
-                  semesters.map((semester) => (
-                    <SelectItem key={semester.id} value={String(semester.id)}>
-                      {buildSemesterLabel(semester) ||
-                        `Semester ${semester.semester}`}
-                    </SelectItem>
-                  ))
-                ) : (
-                  <SelectItem value="" disabled>
-                    Data semester belum tersedia
-                  </SelectItem>
-                )}
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="grid grid-cols-2 gap-4">
+        <form onSubmit={handleAddAttendance} className="space-y-6">
+          <div className="space-y-4">
+            <h3 className="text-sm font-semibold text-foreground">
+              Langkah 1: Mata Pelajaran
+            </h3>
             <div className="space-y-2">
-              <Label>Status Kehadiran</Label>
+              <Label>Mata Pelajaran</Label>
               <Select
-                value={attendanceForm.status}
-                onValueChange={(value) =>
+                disabled={isSubjectLocked}
+                value={
+                  attendanceForm.subjectId && attendanceForm.kelasId
+                    ? `${attendanceForm.subjectId}-${attendanceForm.kelasId}`
+                    : ""
+                }
+                onValueChange={(value) => {
+                  const [subjectId, kelasId] = value.split("-");
                   setAttendanceForm((prev) => ({
                     ...prev,
-                    status: value,
-                  }))
-                }
+                    subjectId,
+                    kelasId,
+                    studentId: "",
+                  }));
+                }}
               >
-                <SelectTrigger>
-                  <SelectValue placeholder="Pilih status" />
+                <SelectTrigger disabled={isSubjectLocked}>
+                  <SelectValue placeholder="Pilih mata pelajaran">
+                    {attendanceForm.subjectId
+                      ? `${getSubjectName(attendanceForm.subjectId)} (${getClassesName(attendanceForm.kelasId)})`
+                      : "Pilih mata pelajaran"}
+                  </SelectValue>
                 </SelectTrigger>
                 <SelectContent>
-                  {attendanceStatuses.map((status) => (
-                    <SelectItem key={status.value} value={status.value}>
-                      {status.label}
+                  {subjects.map((subject, idx) => (
+                    <SelectItem
+                      key={`${subject.id}-${subject.kelasId}-${idx}`}
+                      value={`${subject.id}-${subject.kelasId}`}
+                    >
+                      {subject.nama} ({getClassesName(subject.kelasId)})
                     </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
-            </div>
-
-            <div className="space-y-2">
-              <Label>Tanggal</Label>
-              <Input
-                type="date"
-                value={attendanceForm.tanggal}
-                onChange={(e) =>
-                  setAttendanceForm((prev) => ({
-                    ...prev,
-                    tanggal: e.target.value,
-                  }))
-                }
-              />
+              <p className="text-xs text-muted-foreground">
+                {isSubjectLocked
+                  ? "Mata pelajaran dan kelas ditetapkan dari konteks pilihan Anda."
+                  : "Pilih mata pelajaran dan kelas yang ingin dicatat."}
+              </p>
             </div>
           </div>
 
-          <div className="space-y-2">
-            <Label>Keterangan (Opsional)</Label>
-            <Input
-              type="text"
-              value={attendanceForm.keterangan}
-              onChange={(e) =>
-                setAttendanceForm((prev) => ({
-                  ...prev,
-                  keterangan: e.target.value,
-                }))
-              }
-              placeholder="Masukkan keterangan jika diperlukan"
-            />
+          <Separator />
+
+          <div className="space-y-4">
+            <h3 className="text-sm font-semibold text-foreground">
+              Langkah 2: Pilih Siswa
+            </h3>
+            <div className="space-y-2">
+              <Label>Siswa</Label>
+              <Select
+                value={attendanceForm.studentId}
+                onValueChange={(value) =>
+                  setAttendanceForm((prev) => ({
+                    ...prev,
+                    studentId: value,
+                  }))
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Pilih siswa">
+                    {getStudentName(attendanceForm.studentId)}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  {students
+                    .filter(
+                      (s) => String(s.kelasId) === String(attendanceForm.kelasId)
+                    )
+                    .map((student) => (
+                      <SelectItem key={student.id} value={String(student.id)}>
+                        {student.nama} ({student.nisn})
+                      </SelectItem>
+                    ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                Siswa ditampilkan berdasarkan kelas yang dipilih.
+              </p>
+            </div>
+          </div>
+
+          <Separator />
+
+          <div className="space-y-4">
+            <h3 className="text-sm font-semibold text-foreground">
+              Langkah 3: Isi Kehadiran
+            </h3>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label>Semester</Label>
+                <Select
+                  value={attendanceForm.semesterId || ""}
+                  onValueChange={(value) =>
+                    setAttendanceForm((prev) => ({
+                      ...prev,
+                      semesterId: value,
+                    }))
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Pilih semester">
+                      {attendanceForm.semesterId
+                        ? getSemesterLabelById(attendanceForm.semesterId)
+                        : semesters.length > 0
+                        ? "Pilih semester"
+                        : "Semester belum tersedia"}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {semesters.length > 0 ? (
+                      semesters.map((semester) => (
+                        <SelectItem key={semester.id} value={String(semester.id)}>
+                          {buildSemesterLabel(semester) ||
+                            `Semester ${semester.semester}`}
+                        </SelectItem>
+                      ))
+                    ) : (
+                      <SelectItem value="" disabled>
+                        Data semester belum tersedia
+                      </SelectItem>
+                    )}
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  Pilih semester sesuai jadwal akademik.
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <Label>Status Kehadiran</Label>
+                <Select
+                  value={attendanceForm.status}
+                  onValueChange={(value) =>
+                    setAttendanceForm((prev) => ({
+                      ...prev,
+                      status: value,
+                    }))
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Pilih status" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {attendanceStatuses.map((status) => (
+                      <SelectItem key={status.value} value={status.value}>
+                        {status.label}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  Tentukan status kehadiran siswa.
+                </p>
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label>Tanggal</Label>
+                <Input
+                  type="date"
+                  value={attendanceForm.tanggal}
+                  onChange={(e) =>
+                    setAttendanceForm((prev) => ({
+                      ...prev,
+                      tanggal: e.target.value,
+                    }))
+                  }
+                />
+                <p className="text-xs text-muted-foreground">
+                  Pilih tanggal sesuai tanggal mengajar.
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <Label>Keterangan (Opsional)</Label>
+                <Input
+                  type="text"
+                  value={attendanceForm.keterangan}
+                  onChange={(e) =>
+                    setAttendanceForm((prev) => ({
+                      ...prev,
+                      keterangan: e.target.value,
+                    }))
+                  }
+                  placeholder="Masukkan keterangan jika diperlukan"
+                />
+                <p className="text-xs text-muted-foreground">
+                  Tambahkan catatan tambahan bila diperlukan.
+                </p>
+              </div>
+            </div>
           </div>
 
           <Button type="submit" className="w-full">
-            {editingAttendance ? "Update Kehadiran" : "Simpan Kehadiran"}
+            {editingAttendance
+              ? "Perbarui Kehadiran Ini"
+              : "Simpan Kehadiran Ini"}
           </Button>
         </form>
       </DialogContent>

--- a/src/components/guru/TeacherDashboardTabs.tsx
+++ b/src/components/guru/TeacherDashboardTabs.tsx
@@ -51,6 +51,8 @@ export function TeacherDashboardTabs({
     setShowGradeDialog,
     setAttendanceForm,
     setShowAttendanceDialog,
+    setGradeContextLock,
+    setAttendanceContextLock,
   } = dashboard;
 
   return (
@@ -118,10 +120,19 @@ export function TeacherDashboardTabs({
                           <DropdownMenuSeparator />
                           <DropdownMenuItem
                             onSelect={() => {
+                              const subjectId = String(subject.id);
+                              const kelasId = subject.kelasId
+                                ? String(subject.kelasId)
+                                : "";
                               setGradeForm((prev) => ({
                                 ...prev,
-                                subjectId: String(subject.id),
+                                subjectId,
+                                kelasId,
                               }));
+                              setGradeContextLock({
+                                subjectId,
+                                kelasId,
+                              });
                               setShowGradeDialog(true);
                             }}
                             className="gap-2"
@@ -130,11 +141,19 @@ export function TeacherDashboardTabs({
                           </DropdownMenuItem>
                           <DropdownMenuItem
                             onSelect={() => {
+                              const subjectId = String(subject.id);
+                              const kelasId = subject.kelasId
+                                ? String(subject.kelasId)
+                                : "";
                               setAttendanceForm((prev) => ({
                                 ...prev,
-                                subjectId: String(subject.id),
-                                kelasId: subject.kelasId ? String(subject.kelasId) : "",
+                                subjectId,
+                                kelasId,
                               }));
+                              setAttendanceContextLock({
+                                subjectId,
+                                kelasId,
+                              });
                               setShowAttendanceDialog(true);
                             }}
                             className="gap-2"

--- a/src/components/guru/TeacherGradeDialog.tsx
+++ b/src/components/guru/TeacherGradeDialog.tsx
@@ -9,6 +9,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
 import { Input } from "@/components/ui/input";
+import { Separator } from "@/components/ui/separator";
 import {
   Select,
   SelectContent,
@@ -49,7 +50,13 @@ export function TeacherGradeDialog({
     getStudentName,
     handleAddGrade,
     editingGrade,
+    gradeContextLock,
   } = dashboard;
+
+  const isSubjectLocked =
+    !editingGrade &&
+    !!gradeContextLock?.subjectId &&
+    !!gradeContextLock?.kelasId;
 
   return (
     <Dialog open={showGradeDialog} onOpenChange={handleGradeDialogOpenChange}>
@@ -65,164 +72,204 @@ export function TeacherGradeDialog({
             {editingGrade ? "Edit Nilai Siswa" : "Input Nilai Siswa"}
           </DialogTitle>
         </DialogHeader>
-        <form onSubmit={handleAddGrade} className="space-y-4">
-          <div className="space-y-2">
-            <Label>Mata Pelajaran</Label>
-            <Select
-              value={
-                gradeForm.subjectId && gradeForm.kelasId
-                  ? `${gradeForm.subjectId}-${gradeForm.kelasId}`
-                  : ""
-              }
-              onValueChange={(value) => {
-                const [subjectId, kelasId] = value.split("-");
-                setGradeForm((prev) => ({
-                  ...prev,
-                  subjectId,
-                  kelasId,
-                  studentId: "",
-                }));
-              }}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Pilih mata pelajaran" />
-              </SelectTrigger>
-              <SelectContent>
-                {subjects.map((subject, idx) => (
-                  <SelectItem
-                    key={`${subject.id}-${subject.kelasId}-${idx}`}
-                    value={`${subject.id}-${subject.kelasId}`}
-                  >
-                    {subject.nama} ({getClassesName(subject.kelasId)})
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="space-y-2">
-            <Label>Siswa</Label>
-            <Select
-              value={gradeForm.studentId}
-              onValueChange={(value) =>
-                setGradeForm((prev) => ({ ...prev, studentId: value }))
-              }
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Pilih siswa">
-                  {getStudentName(gradeForm.studentId)}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                {students
-                  .filter(
-                    (s) => String(s.kelasId) === String(gradeForm.kelasId)
-                  )
-                  .map((student) => (
-                    <SelectItem key={student.id} value={String(student.id)}>
-                      {student.nama} ({student.nisn})
-                    </SelectItem>
-                  ))}
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="space-y-2">
-            <Label>Semester</Label>
-            <Select
-              value={gradeForm.semesterId || ""}
-              onValueChange={(value) =>
-                setGradeForm((prev) => ({
-                  ...prev,
-                  semesterId: value,
-                }))
-              }
-            >
-              <SelectTrigger>
-                <SelectValue placeholder="Pilih semester">
-                  {gradeForm.semesterId
-                    ? getSemesterLabelById(gradeForm.semesterId)
-                    : semesters.length > 0
-                    ? "Pilih semester"
-                    : "Semester belum tersedia"}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                {semesters.length > 0 ? (
-                  semesters.map((semester) => (
-                    <SelectItem key={semester.id} value={String(semester.id)}>
-                      {buildSemesterLabel(semester) ||
-                        `Semester ${semester.semester}`}
-                    </SelectItem>
-                  ))
-                ) : (
-                  <SelectItem value="" disabled>
-                    Data semester belum tersedia
-                  </SelectItem>
-                )}
-              </SelectContent>
-            </Select>
-          </div>
-
-          <div className="grid grid-cols-2 gap-4">
+        <form onSubmit={handleAddGrade} className="space-y-6">
+          <div className="space-y-4">
+            <h3 className="text-sm font-semibold text-foreground">
+              Langkah 1: Mata Pelajaran
+            </h3>
             <div className="space-y-2">
-              <Label>Jenis Nilai</Label>
+              <Label>Mata Pelajaran</Label>
               <Select
-                value={gradeForm.jenis}
-                onValueChange={(value) =>
+                disabled={isSubjectLocked}
+                value={
+                  gradeForm.subjectId && gradeForm.kelasId
+                    ? `${gradeForm.subjectId}-${gradeForm.kelasId}`
+                    : ""
+                }
+                onValueChange={(value) => {
+                  const [subjectId, kelasId] = value.split("-");
                   setGradeForm((prev) => ({
                     ...prev,
-                    jenis: value,
-                  }))
-                }
+                    subjectId,
+                    kelasId,
+                    studentId: "",
+                  }));
+                }}
               >
-                <SelectTrigger>
-                  <SelectValue placeholder="Pilih jenis nilai" />
+                <SelectTrigger disabled={isSubjectLocked}>
+                  <SelectValue placeholder="Pilih mata pelajaran" />
                 </SelectTrigger>
                 <SelectContent>
-                  {gradeTypes.map((type) => (
-                    <SelectItem key={type} value={type}>
-                      {type}
+                  {subjects.map((subject, idx) => (
+                    <SelectItem
+                      key={`${subject.id}-${subject.kelasId}-${idx}`}
+                      value={`${subject.id}-${subject.kelasId}`}
+                    >
+                      {subject.nama} ({getClassesName(subject.kelasId)})
                     </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
-            </div>
-
-            <div className="space-y-2">
-              <Label>Nilai</Label>
-              <Input
-                type="number"
-                min={0}
-                max={100}
-                value={gradeForm.nilai}
-                onChange={(e) =>
-                  setGradeForm((prev) => ({
-                    ...prev,
-                    nilai: e.target.value,
-                  }))
-                }
-                placeholder="Masukkan nilai"
-              />
+              <p className="text-xs text-muted-foreground">
+                {isSubjectLocked
+                  ? "Mata pelajaran dan kelas ditetapkan dari konteks pilihan Anda."
+                  : "Pilih mata pelajaran dan kelas yang ingin dinilai."}
+              </p>
             </div>
           </div>
 
-          <div className="space-y-2">
-            <Label>Tanggal</Label>
-            <Input
-              type="date"
-              value={gradeForm.tanggal}
-              onChange={(e) =>
-                setGradeForm((prev) => ({
-                  ...prev,
-                  tanggal: e.target.value,
-                }))
-              }
-            />
+          <Separator />
+
+          <div className="space-y-4">
+            <h3 className="text-sm font-semibold text-foreground">
+              Langkah 2: Pilih Siswa
+            </h3>
+            <div className="space-y-2">
+              <Label>Siswa</Label>
+              <Select
+                value={gradeForm.studentId}
+                onValueChange={(value) =>
+                  setGradeForm((prev) => ({ ...prev, studentId: value }))
+                }
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Pilih siswa">
+                    {getStudentName(gradeForm.studentId)}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  {students
+                    .filter(
+                      (s) => String(s.kelasId) === String(gradeForm.kelasId)
+                    )
+                    .map((student) => (
+                      <SelectItem key={student.id} value={String(student.id)}>
+                        {student.nama} ({student.nisn})
+                      </SelectItem>
+                    ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                Siswa ditampilkan berdasarkan kelas yang dipilih.
+              </p>
+            </div>
+          </div>
+
+          <Separator />
+
+          <div className="space-y-4">
+            <h3 className="text-sm font-semibold text-foreground">
+              Langkah 3: Isi Nilai
+            </h3>
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label>Semester</Label>
+                <Select
+                  value={gradeForm.semesterId || ""}
+                  onValueChange={(value) =>
+                    setGradeForm((prev) => ({
+                      ...prev,
+                      semesterId: value,
+                    }))
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Pilih semester">
+                      {gradeForm.semesterId
+                        ? getSemesterLabelById(gradeForm.semesterId)
+                        : semesters.length > 0
+                        ? "Pilih semester"
+                        : "Semester belum tersedia"}
+                    </SelectValue>
+                  </SelectTrigger>
+                  <SelectContent>
+                    {semesters.length > 0 ? (
+                      semesters.map((semester) => (
+                        <SelectItem key={semester.id} value={String(semester.id)}>
+                          {buildSemesterLabel(semester) ||
+                            `Semester ${semester.semester}`}
+                        </SelectItem>
+                      ))
+                    ) : (
+                      <SelectItem value="" disabled>
+                        Data semester belum tersedia
+                      </SelectItem>
+                    )}
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  Pilih semester sesuai jadwal akademik.
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <Label>Jenis Nilai</Label>
+                <Select
+                  value={gradeForm.jenis}
+                  onValueChange={(value) =>
+                    setGradeForm((prev) => ({
+                      ...prev,
+                      jenis: value,
+                    }))
+                  }
+                >
+                  <SelectTrigger>
+                    <SelectValue placeholder="Pilih jenis nilai" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {gradeTypes.map((type) => (
+                      <SelectItem key={type} value={type}>
+                        {type}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  Pilih jenis penilaian yang sesuai.
+                </p>
+              </div>
+            </div>
+
+            <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-2">
+                <Label>Nilai</Label>
+                <Input
+                  type="number"
+                  min={0}
+                  max={100}
+                  value={gradeForm.nilai}
+                  onChange={(e) =>
+                    setGradeForm((prev) => ({
+                      ...prev,
+                      nilai: e.target.value,
+                    }))
+                  }
+                  placeholder="Masukkan nilai"
+                />
+                <p className="text-xs text-muted-foreground">Nilai 0–100.</p>
+              </div>
+
+              <div className="space-y-2">
+                <Label>Tanggal</Label>
+                <Input
+                  type="date"
+                  value={gradeForm.tanggal}
+                  onChange={(e) =>
+                    setGradeForm((prev) => ({
+                      ...prev,
+                      tanggal: e.target.value,
+                    }))
+                  }
+                />
+                <p className="text-xs text-muted-foreground">
+                  Pilih tanggal sesuai tanggal mengajar.
+                </p>
+              </div>
+            </div>
           </div>
 
           <Button type="submit" className="w-full">
-            {editingGrade ? "Update Nilai" : "Simpan Nilai"}
+            {editingGrade ? "Perbarui Nilai Ini" : "Simpan Nilai Ini"}
           </Button>
         </form>
       </DialogContent>

--- a/src/components/guru/TeacherStudentListDialog.tsx
+++ b/src/components/guru/TeacherStudentListDialog.tsx
@@ -28,6 +28,8 @@ export function TeacherStudentListDialog({
     setAttendanceForm,
     setShowGradeDialog,
     setShowAttendanceDialog,
+    setGradeContextLock,
+    setAttendanceContextLock,
   } = dashboard;
 
   return (
@@ -63,34 +65,56 @@ export function TeacherStudentListDialog({
                   <Button
                     size="sm"
                     variant="outline"
-                  onClick={() => {
-                    setGradeForm((prev) => ({
-                      ...prev,
-                      studentId: String(student.id),
-                      subjectId: selectedSubjectId
+                    onClick={() => {
+                      const subjectId = selectedSubjectId
                         ? String(selectedSubjectId)
-                        : "",
-                    }));
-                    setShowStudentListDialog(false);
-                    setShowGradeDialog(true);
-                  }}
-                >
+                        : "";
+                      const kelasId = selectedSubjectKelasId
+                        ? String(selectedSubjectKelasId)
+                        : "";
+                      setGradeForm((prev) => ({
+                        ...prev,
+                        studentId: String(student.id),
+                        subjectId,
+                        kelasId,
+                      }));
+                      if (subjectId) {
+                        setGradeContextLock({
+                          subjectId,
+                          kelasId,
+                        });
+                      }
+                      setShowStudentListDialog(false);
+                      setShowGradeDialog(true);
+                    }}
+                  >
                     Input Nilai
                   </Button>
                   <Button
                     size="sm"
                     variant="outline"
-                  onClick={() => {
-                    setAttendanceForm((prev) => ({
-                      ...prev,
-                      studentId: String(student.id),
-                      subjectId: selectedSubjectId
+                    onClick={() => {
+                      const subjectId = selectedSubjectId
                         ? String(selectedSubjectId)
-                        : "",
-                    }));
-                    setShowStudentListDialog(false);
-                    setShowAttendanceDialog(true);
-                  }}
+                        : "";
+                      const kelasId = selectedSubjectKelasId
+                        ? String(selectedSubjectKelasId)
+                        : "";
+                      setAttendanceForm((prev) => ({
+                        ...prev,
+                        studentId: String(student.id),
+                        subjectId,
+                        kelasId,
+                      }));
+                      if (subjectId) {
+                        setAttendanceContextLock({
+                          subjectId,
+                          kelasId,
+                        });
+                      }
+                      setShowStudentListDialog(false);
+                      setShowAttendanceDialog(true);
+                    }}
                   >
                     Input Kehadiran
                   </Button>

--- a/src/hooks/use-teacher-dashboard.ts
+++ b/src/hooks/use-teacher-dashboard.ts
@@ -251,6 +251,20 @@ export function useTeacherDashboard(currentUser: TeacherDashboardUser | null) {
   const [editingAttendance, setEditingAttendance] = useState<
     AttendanceRecord | null
   >(null);
+  const [gradeContextLock, setGradeContextLock] = useState<
+    | {
+        subjectId?: string;
+        kelasId?: string;
+      }
+    | null
+  >(null);
+  const [attendanceContextLock, setAttendanceContextLock] = useState<
+    | {
+        subjectId?: string;
+        kelasId?: string;
+      }
+    | null
+  >(null);
   const { toast } = useToast();
   const [semesterWarning, setSemesterWarning] = useState<string>("");
   const [uploadBlockedReason, setUploadBlockedReason] = useState<string>("");
@@ -302,33 +316,31 @@ export function useTeacherDashboard(currentUser: TeacherDashboardUser | null) {
     []
   );
 
-  const resetGradeForm = useCallback(
-    () =>
-      setGradeForm({
-        studentId: "",
-        subjectId: "",
-        jenis: "",
-        nilai: "",
-        kelasId: "",
-        tanggal: new Date().toISOString().split("T")[0],
-        semesterId: selectedSemesterId || "",
-      }),
-    [selectedSemesterId]
-  );
+  const resetGradeForm = useCallback(() => {
+    setGradeForm({
+      studentId: "",
+      subjectId: "",
+      jenis: "",
+      nilai: "",
+      kelasId: "",
+      tanggal: new Date().toISOString().split("T")[0],
+      semesterId: selectedSemesterId || "",
+    });
+    setGradeContextLock(null);
+  }, [selectedSemesterId]);
 
-  const resetAttendanceForm = useCallback(
-    () =>
-      setAttendanceForm({
-        studentId: "",
-        subjectId: "",
-        status: "",
-        keterangan: "",
-        kelasId: "",
-        tanggal: new Date().toISOString().split("T")[0],
-        semesterId: selectedSemesterId || "",
-      }),
-    [selectedSemesterId]
-  );
+  const resetAttendanceForm = useCallback(() => {
+    setAttendanceForm({
+      studentId: "",
+      subjectId: "",
+      status: "",
+      keterangan: "",
+      kelasId: "",
+      tanggal: new Date().toISOString().split("T")[0],
+      semesterId: selectedSemesterId || "",
+    });
+    setAttendanceContextLock(null);
+  }, [selectedSemesterId]);
 
   const handleGradeDialogOpenChange = useCallback(
     (open: boolean) => {
@@ -1585,6 +1597,10 @@ export function useTeacherDashboard(currentUser: TeacherDashboardUser | null) {
     selectedSubjectForAttendance,
     semesterWarning,
     uploadBlockedReason,
+    gradeContextLock,
+    setGradeContextLock,
+    attendanceContextLock,
+    setAttendanceContextLock,
   };
 }
 


### PR DESCRIPTION
## Summary
- restructure grade and attendance dialogs into guided, titled steps with separators and contextual help text
- prefill and lock subject/class selections when dialogs open from subject cards or student list shortcuts
- extend teacher dashboard state to track context locks and reset them when dialogs close

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68f713ca0aa883329362847646649c21