### PR TITLE
style: refresh teacher dashboard accents

### DIFF
--- a/src/components/guru/TeacherDashboardStats.tsx
+++ b/src/components/guru/TeacherDashboardStats.tsx
@@ -13,9 +13,9 @@ export function TeacherDashboardStats({
 }: TeacherDashboardStatsProps) {
   return (
     <div className="mb-6">
-      <div className="flex flex-wrap items-center justify-between gap-6 rounded-xl border border-muted/40 bg-muted/30 px-4 py-4">
+      <div className="flex flex-wrap items-center justify-between gap-6 rounded-xl border border-primary/20 bg-primary/10 px-4 py-4">
         <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-background shadow-sm">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/20 shadow-sm">
             <BookOpen className="h-5 w-5 text-primary" />
           </div>
           <div className="leading-tight">
@@ -27,7 +27,7 @@ export function TeacherDashboardStats({
         </div>
 
         <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-background shadow-sm">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/20 shadow-sm">
             <Users className="h-5 w-5 text-accent" />
           </div>
           <div className="leading-tight">
@@ -39,7 +39,7 @@ export function TeacherDashboardStats({
         </div>
 
         <div className="flex items-center gap-3">
-          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-background shadow-sm">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary/20 shadow-sm">
             <FileText className="h-5 w-5 text-success" />
           </div>
           <div className="leading-tight">

--- a/src/components/guru/TeacherDashboardTabs.tsx
+++ b/src/components/guru/TeacherDashboardTabs.tsx
@@ -93,7 +93,7 @@ export function TeacherDashboardTabs({
                 <AccordionItem
                   key={subject.id}
                   value={`${subject.id}-${subject.kelasId}`}
-                  className="rounded-xl border border-border bg-card shadow-soft"
+                  className="rounded-xl border border-primary/20 bg-primary/5 shadow-soft"
                 >
                   <div className="px-4 pt-4">
                     <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
@@ -175,7 +175,7 @@ export function TeacherDashboardTabs({
                             {subjectGrades.slice(-3).map((grade) => (
                               <li
                                 key={grade.id}
-                                className="rounded-md border border-border/60 bg-background px-3 py-2 shadow-sm"
+                                className="rounded-md border border-primary/20 bg-primary/5 px-3 py-2 shadow-sm"
                               >
                                 <p className="font-medium text-foreground">
                                   {grade.studentName}
@@ -228,7 +228,7 @@ export function TeacherDashboardTabs({
                             {subjectAttendance.slice(-3).map((att) => (
                               <li
                                 key={att.id}
-                                className="rounded-md border border-border/60 bg-background px-3 py-2 shadow-sm"
+                                className="rounded-md border border-primary/20 bg-primary/5 px-3 py-2 shadow-sm"
                               >
                                 <p className="font-medium text-foreground">
                                   {att.studentName}
@@ -271,7 +271,7 @@ export function TeacherDashboardTabs({
                         )}
                       </div>
 
-                      <div className="rounded-lg border border-border/70 bg-background px-4 py-3 shadow-sm">
+                      <div className="rounded-lg bg-primary/5 px-4 py-3 shadow-sm">
                         <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
                           <div>
                             <p className="text-sm font-semibold text-foreground">
@@ -317,7 +317,7 @@ export function TeacherDashboardTabs({
                 {students.map((student) => (
                   <div
                     key={student.id}
-                    className="flex justify-between items-center p-4 border border-border rounded-lg"
+                    className="flex items-center justify-between rounded-lg bg-muted/20 p-4 shadow-sm"
                   >
                     <div className="flex items-center space-x-4">
                       <div className="p-2 bg-primary/10 rounded-lg">


### PR DESCRIPTION
## Summary
- tint the teacher dashboard stat wrapper and icon containers with primary accents
- add subtle primary backgrounds to accordion items and summary list entries
- soften student management and roster cards with muted backgrounds and fewer borders

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f7197332588332afc04db090066993