### PR TITLE
Add teaching day progress info to teacher dashboard header

### DIFF
--- a/src/components/guru/TeacherDashboardHeader.tsx
+++ b/src/components/guru/TeacherDashboardHeader.tsx
@@ -21,11 +21,15 @@ import type { TeacherDashboardUser } from "@/hooks/use-teacher-dashboard";
 type TeacherDashboardHeaderProps = {
   currentUser: TeacherDashboardUser | null;
   onLogout: () => void;
+  teachingDayMessage?: string | null;
+  teachingDayDateLabel?: string | null;
 };
 
 export function TeacherDashboardHeader({
   currentUser,
   onLogout,
+  teachingDayMessage,
+  teachingDayDateLabel,
 }: TeacherDashboardHeaderProps) {
   return (
     <Card className="border-none bg-gradient-to-r from-primary/20 via-primary/10 to-background">
@@ -43,6 +47,19 @@ export function TeacherDashboardHeader({
                 Senang kamu di sini lagi. Yuk, kita rapikan info kelas dan tugas
                 hari ini bareng-bareng.
               </p>
+              <div className="mt-4 rounded-lg border border-primary/10 bg-background/70 px-4 py-3 shadow-sm">
+                <p className="text-xs font-semibold uppercase tracking-wide text-primary">
+                  Kalender Mengajar
+                </p>
+                {teachingDayDateLabel ? (
+                  <p className="mt-1 text-sm font-medium text-foreground">
+                    {teachingDayDateLabel}
+                  </p>
+                ) : null}
+                <p className="mt-1 text-sm text-muted-foreground">
+                  {teachingDayMessage ?? "Data hari mengajar belum tersedia."}
+                </p>
+              </div>
             </div>
           </div>
 

--- a/src/pages/guru/Dashboard.tsx
+++ b/src/pages/guru/Dashboard.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from "react";
 import { TeacherDashboardHeader } from "@/components/guru/TeacherDashboardHeader";
 import { TeacherSemesterSelector } from "@/components/guru/TeacherSemesterSelector";
 import { TeacherDashboardStats } from "@/components/guru/TeacherDashboardStats";
@@ -12,6 +13,7 @@ import {
   type TeacherDashboardUser,
   useTeacherDashboard,
 } from "@/hooks/use-teacher-dashboard";
+import { formatDate, getStudyDayNumber } from "@/utils/helpers";
 
 type TeacherDashboardProps = {
   currentUser: TeacherDashboardUser | null;
@@ -29,13 +31,103 @@ const TeacherDashboard = ({ currentUser, onLogout }: TeacherDashboardProps) => {
     semesters,
   } = dashboard;
 
-  const { buildSemesterLabel, getSemesterLabelById } = useDashboardSemester({
+  const {
+    buildSemesterLabel,
+    getSemesterLabelById,
+    normalizeSemesterMetadata,
+    resolveSemesterMetadata,
+  } = useDashboardSemester({
     semesters,
   });
 
+  const activeSemesterMetadata = useMemo(() => {
+    if (selectedSemesterId) {
+      const resolved = resolveSemesterMetadata(selectedSemesterId);
+      if (resolved) {
+        return resolved;
+      }
+    }
+
+    for (const record of semesters) {
+      const metadata = normalizeSemesterMetadata(record);
+      if (metadata?.isActive) {
+        return metadata;
+      }
+    }
+
+    if (semesters.length > 0) {
+      return normalizeSemesterMetadata(semesters[0]);
+    }
+
+    return null;
+  }, [
+    normalizeSemesterMetadata,
+    resolveSemesterMetadata,
+    selectedSemesterId,
+    semesters,
+  ]);
+
+  const todayLabel = useMemo(() => formatDate(new Date()), []);
+
+  const currentTeachingDay = useMemo(() => {
+    if (!activeSemesterMetadata) return null;
+    return (
+      getStudyDayNumber(new Date(), {
+        semesterMetadata: activeSemesterMetadata,
+      }) ?? null
+    );
+  }, [activeSemesterMetadata]);
+
+  const totalTeachingDays = useMemo(() => {
+    if (!activeSemesterMetadata) return null;
+    const raw = activeSemesterMetadata.jumlahHariBelajar;
+
+    if (raw === null || raw === undefined) return null;
+
+    if (typeof raw === "number") {
+      return Number.isFinite(raw) && raw > 0 ? raw : null;
+    }
+
+    if (typeof raw === "string") {
+      const trimmed = raw.trim();
+      if (!trimmed) return null;
+      const numericPortion = Number(trimmed.replace(/[^0-9.,-]/g, "").replace(/,/g, "."));
+      if (!Number.isNaN(numericPortion) && numericPortion > 0) {
+        return Math.round(numericPortion);
+      }
+    }
+
+    return null;
+  }, [activeSemesterMetadata]);
+
+  const teachingDayMessage = useMemo(() => {
+    if (!activeSemesterMetadata) {
+      return null;
+    }
+
+    if (currentTeachingDay && totalTeachingDays) {
+      return `Sekarang hari ke ${currentTeachingDay} dari ${totalTeachingDays} hari mengajar.`;
+    }
+
+    if (currentTeachingDay) {
+      return `Sekarang hari ke ${currentTeachingDay} dalam kalender mengajar.`;
+    }
+
+    if (totalTeachingDays) {
+      return `Semester ini memiliki ${totalTeachingDays} hari mengajar.`;
+    }
+
+    return null;
+  }, [activeSemesterMetadata, currentTeachingDay, totalTeachingDays]);
+
   return (
     <div className="min-h-screen bg-background">
-      <TeacherDashboardHeader currentUser={currentUser} onLogout={onLogout} />
+      <TeacherDashboardHeader
+        currentUser={currentUser}
+        onLogout={onLogout}
+        teachingDayDateLabel={todayLabel}
+        teachingDayMessage={teachingDayMessage}
+      />
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 md:py-8">
         <TeacherSemesterSelector


### PR DESCRIPTION
## Summary
- derive active semester metadata on the teacher dashboard to determine teaching day progress
- surface the current date and teaching day message in the teacher dashboard header

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68f71b46b7888332a0a7777d158fc2e9