### PR TITLE
Add walikelas dialogs for attendance and grades

### DIFF
--- a/src/components/WalikelasNavbar.tsx
+++ b/src/components/WalikelasNavbar.tsx
@@ -33,12 +33,16 @@ interface WalikelasNavbarProps {
   activeSection: string;
   setActiveSection: (section: string) => void;
   onLogout: () => void;
+  onOpenAttendanceDialog: () => void;
+  onOpenGradesDialog: () => void;
 }
 
 const WalikelasNavbar = ({
   activeSection,
   setActiveSection,
   onLogout,
+  onOpenAttendanceDialog,
+  onOpenGradesDialog,
 }: WalikelasNavbarProps) => {
   const activeItem = menuItems.find((item) => item.id === activeSection);
 
@@ -56,15 +60,37 @@ const WalikelasNavbar = ({
                 {activeItem?.description || "Kelola kelas Anda"}
               </p>
             </div>
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={onLogout}
-              className="text-destructive hover:text-destructive-foreground hover:bg-destructive"
-            >
-              <LogOut className="h-4 w-4 mr-2" />
-              Logout
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onOpenAttendanceDialog}
+                className="text-muted-foreground hover:text-foreground"
+                aria-label="Buka dialog kehadiran"
+              >
+                <Calendar className="h-4 w-4" />
+                <span className="hidden md:inline ml-2">Kehadiran</span>
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={onOpenGradesDialog}
+                className="text-muted-foreground hover:text-foreground"
+                aria-label="Buka dialog nilai"
+              >
+                <CheckCircle className="h-4 w-4" />
+                <span className="hidden md:inline ml-2">Nilai</span>
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={onLogout}
+                className="text-destructive hover:text-destructive-foreground hover:bg-destructive"
+              >
+                <LogOut className="h-4 w-4 mr-2" />
+                Logout
+              </Button>
+            </div>
           </div>
 
           {/* Navigation Menu */}

--- a/src/components/walikelas/AttendanceDialog.tsx
+++ b/src/components/walikelas/AttendanceDialog.tsx
@@ -1,0 +1,54 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Card, CardContent } from "@/components/ui/card";
+import AttendanceList from "@/components/walikelas/AttendanceList";
+
+interface AttendanceRecord {
+  id: string;
+  studentId: string;
+  subjectId: string;
+  status: string;
+  tanggal: string;
+  keterangan?: string;
+}
+
+interface StudentSummary {
+  id: string;
+  nama: string;
+}
+
+interface AttendanceDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  attendance: AttendanceRecord[];
+  students: StudentSummary[];
+  selectedStudentName?: string | null;
+}
+
+const AttendanceDialog = ({
+  open,
+  onOpenChange,
+  attendance,
+  students,
+  selectedStudentName,
+}: AttendanceDialogProps) => {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl w-full">
+        <DialogHeader>
+          <DialogTitle>
+            {selectedStudentName
+              ? `Detail Kehadiran ${selectedStudentName}`
+              : "Detail Kehadiran Siswa"}
+          </DialogTitle>
+        </DialogHeader>
+        <Card className="shadow-none border-none">
+          <CardContent className="px-0">
+            <AttendanceList attendance={attendance} students={students} />
+          </CardContent>
+        </Card>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default AttendanceDialog;

--- a/src/components/walikelas/AttendanceList.tsx
+++ b/src/components/walikelas/AttendanceList.tsx
@@ -1,0 +1,75 @@
+import { Badge } from "@/components/ui/badge";
+import { Calendar } from "lucide-react";
+import { formatDate, getAttendanceStatus } from "@/utils/helpers";
+
+interface AttendanceRecord {
+  id: string;
+  studentId: string;
+  subjectId: string;
+  status: string;
+  tanggal: string;
+  keterangan?: string;
+}
+
+interface StudentSummary {
+  id: string;
+  nama: string;
+}
+
+interface AttendanceListProps {
+  attendance: AttendanceRecord[];
+  students: StudentSummary[];
+}
+
+const AttendanceList = ({ attendance, students }: AttendanceListProps) => {
+  const findStudentName = (studentId: string) =>
+    students.find((student) => student.id === studentId)?.nama || "Siswa";
+
+  if (attendance.length === 0) {
+    return (
+      <div className="text-center py-8">
+        <Calendar className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
+        <p className="text-muted-foreground">Belum ada data kehadiran</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {attendance.map((record) => {
+        const status = getAttendanceStatus(record.status);
+
+        return (
+          <div
+            key={record.id}
+            className="flex flex-col md:flex-row justify-between items-start md:items-center p-4 border border-border rounded-lg space-y-2 md:space-y-0"
+          >
+            <div className="flex-1">
+              <h4 className="font-medium text-foreground">
+                {findStudentName(record.studentId)}
+              </h4>
+              <div className="flex flex-wrap items-center gap-2 mt-1">
+                <Badge variant="outline" className="text-xs">
+                  Mata Pelajaran {record.subjectId}
+                </Badge>
+                <span className="text-xs text-muted-foreground">
+                  {formatDate(record.tanggal)}
+                </span>
+              </div>
+              {record.keterangan && (
+                <p className="text-xs text-muted-foreground mt-1">
+                  {record.keterangan}
+                </p>
+              )}
+            </div>
+            <Badge className={`${status.bgColor} ${status.color}`}>
+              {status.label}
+            </Badge>
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default AttendanceList;

--- a/src/components/walikelas/AttendanceSection.tsx
+++ b/src/components/walikelas/AttendanceSection.tsx
@@ -1,7 +1,5 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Calendar } from "lucide-react";
-import { formatDate, getAttendanceStatus } from "@/utils/helpers";
+import AttendanceList from "@/components/walikelas/AttendanceList";
 
 interface AttendanceRecord {
   id: string;
@@ -23,56 +21,13 @@ interface AttendanceSectionProps {
 }
 
 const AttendanceSection = ({ attendance, students }: AttendanceSectionProps) => {
-  const findStudentName = (studentId: string) =>
-    students.find((student) => student.id === studentId)?.nama || "Siswa";
-
   return (
     <Card className="shadow-soft">
       <CardHeader>
         <CardTitle>Kehadiran Kelas</CardTitle>
       </CardHeader>
       <CardContent>
-        {attendance.length > 0 ? (
-          <div className="space-y-4">
-            {attendance.map((record) => {
-              const status = getAttendanceStatus(record.status);
-
-              return (
-                <div
-                  key={record.id}
-                  className="flex flex-col md:flex-row justify-between items-start md:items-center p-4 border border-border rounded-lg space-y-2 md:space-y-0"
-                >
-                  <div className="flex-1">
-                    <h4 className="font-medium text-foreground">
-                      {findStudentName(record.studentId)}
-                    </h4>
-                    <div className="flex flex-wrap items-center gap-2 mt-1">
-                      <Badge variant="outline" className="text-xs">
-                        Mata Pelajaran {record.subjectId}
-                      </Badge>
-                      <span className="text-xs text-muted-foreground">
-                        {formatDate(record.tanggal)}
-                      </span>
-                    </div>
-                    {record.keterangan && (
-                      <p className="text-xs text-muted-foreground mt-1">
-                        {record.keterangan}
-                      </p>
-                    )}
-                  </div>
-                  <Badge className={`${status.bgColor} ${status.color}`}>
-                    {status.label}
-                  </Badge>
-                </div>
-              );
-            })}
-          </div>
-        ) : (
-          <div className="text-center py-8">
-            <Calendar className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
-            <p className="text-muted-foreground">Belum ada data kehadiran</p>
-          </div>
-        )}
+        <AttendanceList attendance={attendance} students={students} />
       </CardContent>
     </Card>
   );

--- a/src/components/walikelas/GradesDialog.tsx
+++ b/src/components/walikelas/GradesDialog.tsx
@@ -1,0 +1,90 @@
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { CheckSquare } from "lucide-react";
+import GradesList from "@/components/walikelas/GradesList";
+
+interface GradeItem {
+  id: string;
+  studentId: string;
+  subjectId: string;
+  jenis: string;
+  nilai: string | number;
+  tanggal: string;
+  verified?: boolean;
+}
+
+interface StudentSummary {
+  id: string;
+  nama: string;
+}
+
+interface GradesDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  loading: boolean;
+  grades: GradeItem[];
+  students: StudentSummary[];
+  onVerifyGrade: (gradeId: string) => void;
+  onVerifyAll: () => void;
+  selectedStudentName?: string | null;
+}
+
+const GradesDialog = ({
+  open,
+  onOpenChange,
+  loading,
+  grades,
+  students,
+  onVerifyGrade,
+  onVerifyAll,
+  selectedStudentName,
+}: GradesDialogProps) => {
+  const canVerifyAll = grades.length > 0;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-3xl w-full">
+        <DialogHeader>
+          <DialogTitle>
+            {selectedStudentName
+              ? `Verifikasi Nilai ${selectedStudentName}`
+              : "Verifikasi Nilai Siswa"}
+          </DialogTitle>
+        </DialogHeader>
+        <Card className="shadow-none border-none">
+          <CardHeader className="px-0 pt-0">
+            <div className="flex flex-col md:flex-row justify-between items-start md:items-center space-y-4 md:space-y-0">
+              <CardTitle className="text-lg">Daftar Nilai Belum Terverifikasi</CardTitle>
+              {canVerifyAll && (
+                <Button
+                  onClick={onVerifyAll}
+                  disabled={loading}
+                  className="bg-success text-success-foreground w-full md:w-auto"
+                >
+                  <CheckSquare className="h-4 w-4 mr-2" />
+                  Verifikasi Semua ({grades.length})
+                </Button>
+              )}
+            </div>
+          </CardHeader>
+          <CardContent className="px-0">
+            <GradesList
+              loading={loading}
+              grades={grades}
+              students={students}
+              onVerifyGrade={onVerifyGrade}
+            />
+          </CardContent>
+        </Card>
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default GradesDialog;

--- a/src/components/walikelas/GradesList.tsx
+++ b/src/components/walikelas/GradesList.tsx
@@ -1,0 +1,100 @@
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { CheckCircle, Clock } from "lucide-react";
+import { formatDate, getGradeColor } from "@/utils/helpers";
+
+interface GradeItem {
+  id: string;
+  studentId: string;
+  subjectId: string;
+  jenis: string;
+  nilai: string | number;
+  tanggal: string;
+  verified?: boolean;
+}
+
+interface StudentSummary {
+  id: string;
+  nama: string;
+}
+
+interface GradesListProps {
+  loading: boolean;
+  grades: GradeItem[];
+  students: StudentSummary[];
+  onVerifyGrade: (gradeId: string) => void;
+}
+
+const GradesList = ({
+  loading,
+  grades,
+  students,
+  onVerifyGrade,
+}: GradesListProps) => {
+  const findStudentName = (studentId: string) =>
+    students.find((student) => student.id === studentId)?.nama || "Siswa";
+
+  if (loading) {
+    return (
+      <div className="text-center py-8">
+        <Clock className="h-8 w-8 animate-spin mx-auto mb-4 text-muted-foreground" />
+        <p className="text-muted-foreground">Memuat data nilai...</p>
+      </div>
+    );
+  }
+
+  if (grades.length === 0) {
+    return (
+      <div className="text-center py-8">
+        <CheckCircle className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
+        <p className="text-muted-foreground">Semua nilai sudah diverifikasi</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {grades.map((grade) => (
+        <div
+          key={grade.id}
+          className="flex flex-col md:flex-row justify-between items-start md:items-center p-4 border border-border rounded-lg space-y-4 md:space-y-0"
+        >
+          <div className="flex-1">
+            <h4 className="font-medium text-foreground">
+              {findStudentName(grade.studentId)}
+            </h4>
+            <div className="flex flex-wrap items-center gap-2 mt-1">
+              <Badge variant="outline" className="text-xs">
+                Mata Pelajaran {grade.subjectId}
+              </Badge>
+              <Badge variant="outline" className="text-xs">
+                {grade.jenis}
+              </Badge>
+              <span className="text-xs text-muted-foreground">
+                {formatDate(grade.tanggal)}
+              </span>
+            </div>
+          </div>
+          <div className="flex items-center space-x-4">
+            <div className="text-right">
+              <p className={`text-xl font-bold ${getGradeColor(grade.nilai)}`}>
+                {grade.nilai}
+              </p>
+            </div>
+            <Button
+              size="sm"
+              onClick={() => onVerifyGrade(grade.id)}
+              className="bg-success text-success-foreground"
+              aria-label={`Verifikasi nilai ${findStudentName(grade.studentId)}`}
+            >
+              <CheckCircle className="h-4 w-4 mr-2" />
+              Verifikasi
+            </Button>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default GradesList;

--- a/src/components/walikelas/GradesSection.tsx
+++ b/src/components/walikelas/GradesSection.tsx
@@ -1,8 +1,7 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { CheckCircle, CheckSquare, Clock } from "lucide-react";
-import { formatDate, getGradeColor } from "@/utils/helpers";
+import { CheckSquare } from "lucide-react";
+import GradesList from "@/components/walikelas/GradesList";
 
 interface GradeItem {
   id: string;
@@ -34,9 +33,6 @@ const GradesSection = ({
   onVerifyGrade,
   onVerifyAll,
 }: GradesSectionProps) => {
-  const findStudentName = (studentId: string) =>
-    students.find((student) => student.id === studentId)?.nama || "Siswa";
-
   return (
     <Card className="shadow-soft">
       <CardHeader>
@@ -55,59 +51,12 @@ const GradesSection = ({
         </div>
       </CardHeader>
       <CardContent>
-        {loading ? (
-          <div className="text-center py-8">
-            <Clock className="h-8 w-8 animate-spin mx-auto mb-4 text-muted-foreground" />
-            <p className="text-muted-foreground">Memuat data nilai...</p>
-          </div>
-        ) : unverifiedGrades.length > 0 ? (
-          <div className="space-y-4">
-            {unverifiedGrades.map((grade) => (
-              <div
-                key={grade.id}
-                className="flex flex-col md:flex-row justify-between items-start md:items-center p-4 border border-border rounded-lg space-y-4 md:space-y-0"
-              >
-                <div className="flex-1">
-                  <h4 className="font-medium text-foreground">
-                    {findStudentName(grade.studentId)}
-                  </h4>
-                  <div className="flex flex-wrap items-center gap-2 mt-1">
-                    <Badge variant="outline" className="text-xs">
-                      Mata Pelajaran {grade.subjectId}
-                    </Badge>
-                    <Badge variant="outline" className="text-xs">
-                      {grade.jenis}
-                    </Badge>
-                    <span className="text-xs text-muted-foreground">
-                      {formatDate(grade.tanggal)}
-                    </span>
-                  </div>
-                </div>
-                <div className="flex items-center space-x-4">
-                  <div className="text-right">
-                    <p className={`text-xl font-bold ${getGradeColor(grade.nilai)}`}>
-                      {grade.nilai}
-                    </p>
-                  </div>
-                  <Button
-                    size="sm"
-                    onClick={() => onVerifyGrade(grade.id)}
-                    className="bg-success text-success-foreground"
-                    aria-label={`Verifikasi nilai ${findStudentName(grade.studentId)}`}
-                  >
-                    <CheckCircle className="h-4 w-4 mr-2" />
-                    Verifikasi
-                  </Button>
-                </div>
-              </div>
-            ))}
-          </div>
-        ) : (
-          <div className="text-center py-8">
-            <CheckCircle className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
-            <p className="text-muted-foreground">Semua nilai sudah diverifikasi</p>
-          </div>
-        )}
+        <GradesList
+          loading={loading}
+          grades={unverifiedGrades}
+          students={students}
+          onVerifyGrade={onVerifyGrade}
+        />
       </CardContent>
     </Card>
   );

--- a/src/pages/walikelas/Dashboard.tsx
+++ b/src/pages/walikelas/Dashboard.tsx
@@ -1,3 +1,4 @@
+import { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Select,
@@ -19,6 +20,8 @@ import StudentsSection from "@/components/walikelas/StudentsSection";
 import GradesSection from "@/components/walikelas/GradesSection";
 import AttendanceSection from "@/components/walikelas/AttendanceSection";
 import ReportsSection from "@/components/walikelas/ReportsSection";
+import AttendanceDialog from "@/components/walikelas/AttendanceDialog";
+import GradesDialog from "@/components/walikelas/GradesDialog";
 import { useDashboardSemester } from "@/hooks/use-dashboard-semester";
 import useWalikelasDashboard from "@/hooks/use-walikelas-dashboard";
 
@@ -69,6 +72,38 @@ const WalikelasaDashboard = ({ currentUser, onLogout }) => {
     selectedSemesterMetadata
   );
 
+  const [isAttendanceDialogOpen, setAttendanceDialogOpen] = useState(false);
+  const [isGradesDialogOpen, setGradesDialogOpen] = useState(false);
+  const [selectedStudentId, setSelectedStudentId] = useState<string | null>(null);
+
+  const selectedStudentName = selectedStudentId
+    ? students.find((student) => student.id === selectedStudentId)?.nama || null
+    : null;
+
+  const openAttendanceDialog = () => {
+    setSelectedStudentId(null);
+    setAttendanceDialogOpen(true);
+  };
+
+  const openGradesDialog = () => {
+    setSelectedStudentId(null);
+    setGradesDialogOpen(true);
+  };
+
+  const handleAttendanceDialogChange = (open: boolean) => {
+    setAttendanceDialogOpen(open);
+    if (!open) {
+      setSelectedStudentId(null);
+    }
+  };
+
+  const handleGradesDialogChange = (open: boolean) => {
+    setGradesDialogOpen(open);
+    if (!open) {
+      setSelectedStudentId(null);
+    }
+  };
+
   return (
     <div className="min-h-screen bg-background">
       <div className="bg-gradient-to-r from-green-600 to-teal-600 text-white py-6 md:py-8">
@@ -106,6 +141,27 @@ const WalikelasaDashboard = ({ currentUser, onLogout }) => {
         activeSection={activeSection}
         setActiveSection={setActiveSection}
         onLogout={onLogout}
+        onOpenAttendanceDialog={openAttendanceDialog}
+        onOpenGradesDialog={openGradesDialog}
+      />
+
+      <AttendanceDialog
+        open={isAttendanceDialogOpen}
+        onOpenChange={handleAttendanceDialogChange}
+        attendance={attendance}
+        students={students}
+        selectedStudentName={selectedStudentName}
+      />
+
+      <GradesDialog
+        open={isGradesDialogOpen}
+        onOpenChange={handleGradesDialogChange}
+        loading={loading}
+        grades={unverifiedGrades}
+        students={students}
+        onVerifyGrade={handleVerifyGrade}
+        onVerifyAll={handleVerifyAll}
+        selectedStudentName={selectedStudentName}
       />
 
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6 md:py-8">


### PR DESCRIPTION
## Summary
- add attendance and grade dialogs for the walikelas dashboard and expose open handlers via the navbar
- extract shared list components so both sections and dialogs reuse the same rendering logic
- wire the dashboard to manage dialog state and share optional student context across views

## Testing
- npm run lint *(fails: existing lint violations in unrelated student/teacher components and ui primitives)*

------
https://chatgpt.com/codex/tasks/task_e_68f7234265ac8332ba6a4b8fa60de0a7