### PR TITLE
Add attendance and grade quick actions for homeroom students

### DIFF
--- a/src/components/walikelas/StudentsSection.tsx
+++ b/src/components/walikelas/StudentsSection.tsx
@@ -11,7 +11,7 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Badge } from "@/components/ui/badge";
-import { Search, UserPlus, Edit, Trash2 } from "lucide-react";
+import { Search, UserPlus, Edit, Trash2, Calendar, BarChart3 } from "lucide-react";
 import { useIsMobile } from "@/hooks/use-mobile";
 import StudentFormDialog from "./StudentFormDialog";
 
@@ -33,6 +33,8 @@ interface StudentsSectionProps {
   onAddStudent: () => void;
   onEditStudent: (student: Student) => void;
   onDeleteStudent: (studentId: string) => void;
+  onShowAttendance: (studentId: string) => void;
+  onShowGrades: (studentId: string) => void;
   isDialogOpen: boolean;
   onDialogOpenChange: (open: boolean) => void;
   isEditing: boolean;
@@ -50,6 +52,8 @@ const StudentsSection = ({
   onAddStudent,
   onEditStudent,
   onDeleteStudent,
+  onShowAttendance,
+  onShowGrades,
   isDialogOpen,
   onDialogOpenChange,
   isEditing,
@@ -142,7 +146,23 @@ const StudentsSection = ({
                     </TableCell>
                   )}
                   <TableCell className="text-right">
-                    <div className="flex justify-end space-x-2">
+                    <div className="flex flex-wrap justify-end gap-2">
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => onShowAttendance(student.id)}
+                        aria-label={`Lihat kehadiran ${student.nama}`}
+                      >
+                        <Calendar className="h-3 w-3" />
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={() => onShowGrades(student.id)}
+                        aria-label={`Lihat nilai ${student.nama}`}
+                      >
+                        <BarChart3 className="h-3 w-3" />
+                      </Button>
                       <Button
                         size="sm"
                         variant="outline"

--- a/src/pages/walikelas/Dashboard.tsx
+++ b/src/pages/walikelas/Dashboard.tsx
@@ -90,6 +90,24 @@ const WalikelasaDashboard = ({ currentUser, onLogout }) => {
     setGradesDialogOpen(true);
   };
 
+  const handleShowStudentAttendance = (studentId: string) => {
+    setSelectedStudentId(studentId);
+    setAttendanceDialogOpen(true);
+  };
+
+  const handleShowStudentGrades = (studentId: string) => {
+    setSelectedStudentId(studentId);
+    setGradesDialogOpen(true);
+  };
+
+  const filteredAttendanceRecords = selectedStudentId
+    ? attendance.filter((record) => record.studentId === selectedStudentId)
+    : attendance;
+
+  const filteredGradeRecords = selectedStudentId
+    ? unverifiedGrades.filter((grade) => grade.studentId === selectedStudentId)
+    : unverifiedGrades;
+
   const handleAttendanceDialogChange = (open: boolean) => {
     setAttendanceDialogOpen(open);
     if (!open) {
@@ -148,7 +166,7 @@ const WalikelasaDashboard = ({ currentUser, onLogout }) => {
       <AttendanceDialog
         open={isAttendanceDialogOpen}
         onOpenChange={handleAttendanceDialogChange}
-        attendance={attendance}
+        attendance={filteredAttendanceRecords}
         students={students}
         selectedStudentName={selectedStudentName}
       />
@@ -157,7 +175,7 @@ const WalikelasaDashboard = ({ currentUser, onLogout }) => {
         open={isGradesDialogOpen}
         onOpenChange={handleGradesDialogChange}
         loading={loading}
-        grades={unverifiedGrades}
+        grades={filteredGradeRecords}
         students={students}
         onVerifyGrade={handleVerifyGrade}
         onVerifyAll={handleVerifyAll}
@@ -364,6 +382,8 @@ const WalikelasaDashboard = ({ currentUser, onLogout }) => {
               onAddStudent={startAddStudent}
               onEditStudent={editStudent}
               onDeleteStudent={handleDeleteStudent}
+              onShowAttendance={handleShowStudentAttendance}
+              onShowGrades={handleShowStudentGrades}
               isDialogOpen={showStudentDialog}
               onDialogOpenChange={handleStudentDialogChange}
               isEditing={Boolean(editingStudent)}


### PR DESCRIPTION
## Summary
- add attendance and grade quick action props and buttons in the homeroom students table
- track the selected student in the dashboard and filter dialog data before opening attendance/grade dialogs

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68f72804323083328516e9137b9f7274