### PR TITLE
Fix ReportsSection metadata typing for string values

### DIFF
--- a/src/components/walikelas/ReportsSection.tsx
+++ b/src/components/walikelas/ReportsSection.tsx
@@ -21,7 +21,7 @@ interface ReportsSectionProps {
   selectedSemesterPeriodLabel: string;
   selectedSemesterDateRange: string | null;
   selectedSemesterMetadata?: {
-    jumlahHariBelajar?: number | null;
+    jumlahHariBelajar?: number | string | null;
     catatan?: string | null;
   } | null;
   onPrintReport: (student: StudentReportCandidate) => void;


### PR DESCRIPTION
## Summary
- allow the walikelas reports section to accept string semester learning day metadata so it matches the dashboard hook output

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f72a0f658c8332a10ba4fced5776c8