### PR TITLE
feat: enhance walikelas grade dialogs with status filtering

### DIFF
--- a/src/components/walikelas/GradesDialog.tsx
+++ b/src/components/walikelas/GradesDialog.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useMemo, useState } from "react";
 import {
   Dialog,
   DialogContent,
@@ -6,6 +7,13 @@ import {
 } from "@/components/ui/dialog";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { CheckSquare } from "lucide-react";
 import GradesList from "@/components/walikelas/GradesList";
 
@@ -45,7 +53,67 @@ const GradesDialog = ({
   onVerifyAll,
   selectedStudentName,
 }: GradesDialogProps) => {
-  const canVerifyAll = grades.length > 0;
+  const [verificationFilter, setVerificationFilter] = useState<
+    "all" | "verified" | "unverified"
+  >("all");
+
+  const filteredGrades = useMemo(() => {
+    if (verificationFilter === "verified") {
+      return grades.filter((grade) => grade.verified);
+    }
+
+    if (verificationFilter === "unverified") {
+      return grades.filter((grade) => !grade.verified);
+    }
+
+    return grades;
+  }, [grades, verificationFilter]);
+
+  const unverifiedCount = useMemo(
+    () => grades.filter((grade) => !grade.verified).length,
+    [grades]
+  );
+
+  const canVerifyAll = unverifiedCount > 0;
+
+  useEffect(() => {
+    if (!open) {
+      setVerificationFilter("all");
+    }
+  }, [open]);
+
+  const emptyMessage = useMemo(() => {
+    if (grades.length === 0) {
+      return selectedStudentName
+        ? "Belum ada nilai untuk siswa ini."
+        : "Belum ada data nilai yang tersedia.";
+    }
+
+    if (filteredGrades.length === 0) {
+      if (verificationFilter === "verified") {
+        return selectedStudentName
+          ? "Siswa ini belum memiliki nilai yang sudah diverifikasi."
+          : "Belum ada nilai yang sudah diverifikasi.";
+      }
+
+      if (verificationFilter === "unverified") {
+        return selectedStudentName
+          ? "Siswa ini tidak memiliki nilai yang perlu diverifikasi."
+          : "Semua nilai telah diverifikasi.";
+      }
+
+      return selectedStudentName
+        ? "Tidak ada nilai yang sesuai dengan filter ini untuk siswa tersebut."
+        : "Tidak ada nilai yang sesuai dengan filter ini.";
+    }
+
+    return undefined;
+  }, [
+    filteredGrades.length,
+    grades.length,
+    selectedStudentName,
+    verificationFilter,
+  ]);
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -53,32 +121,70 @@ const GradesDialog = ({
         <DialogHeader>
           <DialogTitle>
             {selectedStudentName
-              ? `Verifikasi Nilai ${selectedStudentName}`
-              : "Verifikasi Nilai Siswa"}
+              ? `Data Nilai ${selectedStudentName}`
+              : "Data Nilai Siswa"}
           </DialogTitle>
         </DialogHeader>
         <Card className="shadow-none border-none">
           <CardHeader className="px-0 pt-0">
             <div className="flex flex-col md:flex-row justify-between items-start md:items-center space-y-4 md:space-y-0">
-              <CardTitle className="text-lg">Daftar Nilai Belum Terverifikasi</CardTitle>
-              {canVerifyAll && (
-                <Button
-                  onClick={onVerifyAll}
-                  disabled={loading}
-                  className="bg-success text-success-foreground w-full md:w-auto"
+              <div>
+                <CardTitle className="text-lg">
+                  {selectedStudentName
+                    ? `Daftar Nilai ${selectedStudentName}`
+                    : "Daftar Nilai Siswa"}
+                </CardTitle>
+                <p className="text-sm text-muted-foreground">
+                  {filteredGrades.length} nilai ditampilkan
+                  {verificationFilter !== "all"
+                    ? ` • Filter: ${
+                        verificationFilter === "verified"
+                          ? "Sudah Terverifikasi"
+                          : "Belum Terverifikasi"
+                      }`
+                    : ""}
+                </p>
+              </div>
+              <div className="flex flex-col md:flex-row gap-3 w-full md:w-auto">
+                <Select
+                  value={verificationFilter}
+                  onValueChange={(value) =>
+                    setVerificationFilter(
+                      value as "all" | "verified" | "unverified"
+                    )
+                  }
                 >
-                  <CheckSquare className="h-4 w-4 mr-2" />
-                  Verifikasi Semua ({grades.length})
-                </Button>
-              )}
+                  <SelectTrigger className="w-full md:w-[220px]">
+                    <SelectValue placeholder="Filter verifikasi" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">Semua Nilai</SelectItem>
+                    <SelectItem value="unverified">
+                      Belum Terverifikasi
+                    </SelectItem>
+                    <SelectItem value="verified">Sudah Terverifikasi</SelectItem>
+                  </SelectContent>
+                </Select>
+                {canVerifyAll && (
+                  <Button
+                    onClick={onVerifyAll}
+                    disabled={loading}
+                    className="bg-success text-success-foreground w-full md:w-auto"
+                  >
+                    <CheckSquare className="h-4 w-4 mr-2" />
+                    Verifikasi Semua ({unverifiedCount})
+                  </Button>
+                )}
+              </div>
             </div>
           </CardHeader>
           <CardContent className="px-0">
             <GradesList
               loading={loading}
-              grades={grades}
+              grades={filteredGrades}
               students={students}
               onVerifyGrade={onVerifyGrade}
+              emptyMessage={emptyMessage}
             />
           </CardContent>
         </Card>

--- a/src/components/walikelas/GradesList.tsx
+++ b/src/components/walikelas/GradesList.tsx
@@ -23,6 +23,7 @@ interface GradesListProps {
   grades: GradeItem[];
   students: StudentSummary[];
   onVerifyGrade: (gradeId: string) => void;
+  emptyMessage?: string;
 }
 
 const GradesList = ({
@@ -30,6 +31,7 @@ const GradesList = ({
   grades,
   students,
   onVerifyGrade,
+  emptyMessage,
 }: GradesListProps) => {
   const findStudentName = (studentId: string) =>
     students.find((student) => student.id === studentId)?.nama || "Siswa";
@@ -47,7 +49,9 @@ const GradesList = ({
     return (
       <div className="text-center py-8">
         <CheckCircle className="h-12 w-12 mx-auto mb-4 text-muted-foreground" />
-        <p className="text-muted-foreground">Semua nilai sudah diverifikasi</p>
+        <p className="text-muted-foreground">
+          {emptyMessage || "Belum ada data nilai."}
+        </p>
       </div>
     );
   }
@@ -75,21 +79,36 @@ const GradesList = ({
               </span>
             </div>
           </div>
-          <div className="flex items-center space-x-4">
-            <div className="text-right">
-              <p className={`text-xl font-bold ${getGradeColor(grade.nilai)}`}>
-                {grade.nilai}
-              </p>
+          <div className="flex flex-col items-stretch md:items-end gap-3">
+            <div className="flex items-center gap-3 md:justify-end">
+              <div className="text-right">
+                <p className={`text-xl font-bold ${getGradeColor(grade.nilai)}`}>
+                  {grade.nilai}
+                </p>
+              </div>
+              <Badge
+                variant="outline"
+                className={
+                  grade.verified
+                    ? "border-success/40 text-success"
+                    : "border-warning/40 text-warning"
+                }
+              >
+                {grade.verified ? "Sudah Terverifikasi" : "Belum Terverifikasi"}
+              </Badge>
             </div>
-            <Button
-              size="sm"
-              onClick={() => onVerifyGrade(grade.id)}
-              className="bg-success text-success-foreground"
-              aria-label={`Verifikasi nilai ${findStudentName(grade.studentId)}`}
-            >
-              <CheckCircle className="h-4 w-4 mr-2" />
-              Verifikasi
-            </Button>
+            {!grade.verified && (
+              <Button
+                size="sm"
+                onClick={() => onVerifyGrade(grade.id)}
+                className="bg-success text-success-foreground"
+                aria-label={`Verifikasi nilai ${findStudentName(grade.studentId)}`}
+                disabled={loading}
+              >
+                <CheckCircle className="h-4 w-4 mr-2" />
+                Verifikasi
+              </Button>
+            )}
           </div>
         </div>
       ))}

--- a/src/pages/walikelas/Dashboard.tsx
+++ b/src/pages/walikelas/Dashboard.tsx
@@ -105,8 +105,8 @@ const WalikelasaDashboard = ({ currentUser, onLogout }) => {
     : attendance;
 
   const filteredGradeRecords = selectedStudentId
-    ? unverifiedGrades.filter((grade) => grade.studentId === selectedStudentId)
-    : unverifiedGrades;
+    ? grades.filter((grade) => grade.studentId === selectedStudentId)
+    : grades;
 
   const handleAttendanceDialogChange = (open: boolean) => {
     setAttendanceDialogOpen(open);


### PR DESCRIPTION
## Summary
- show all grade records in the walikelas dialog, including per-student views
- add a verification status filter and contextual empty states in the grade dialog
- update the grade list to display verification badges and disable verification actions for verified items

## Testing
- npm run lint *(fails: pre-existing lint violations unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68f72b792c9483329429f88704afbb31