### PR TITLE
Make walikelas dialogs scrollable

### DIFF
--- a/src/components/walikelas/AttendanceDialog.tsx
+++ b/src/components/walikelas/AttendanceDialog.tsx
@@ -33,19 +33,21 @@ const AttendanceDialog = ({
 }: AttendanceDialogProps) => {
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-3xl w-full">
-        <DialogHeader>
+      <DialogContent className="max-w-3xl w-full max-h-[80vh] flex flex-col overflow-hidden">
+        <DialogHeader className="flex-none">
           <DialogTitle>
             {selectedStudentName
               ? `Detail Kehadiran ${selectedStudentName}`
               : "Detail Kehadiran Siswa"}
           </DialogTitle>
         </DialogHeader>
-        <Card className="shadow-none border-none">
-          <CardContent className="px-0">
-            <AttendanceList attendance={attendance} students={students} />
-          </CardContent>
-        </Card>
+        <div className="flex-1 overflow-y-auto">
+          <Card className="shadow-none border-none flex flex-col h-full overflow-hidden">
+            <CardContent className="px-0 flex-1 overflow-y-auto pr-1">
+              <AttendanceList attendance={attendance} students={students} />
+            </CardContent>
+          </Card>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/walikelas/GradesDialog.tsx
+++ b/src/components/walikelas/GradesDialog.tsx
@@ -117,20 +117,21 @@ const GradesDialog = ({
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="max-w-3xl w-full">
-        <DialogHeader>
+      <DialogContent className="max-w-3xl w-full max-h-[85vh] flex flex-col overflow-hidden">
+        <DialogHeader className="flex-none">
           <DialogTitle>
             {selectedStudentName
               ? `Data Nilai ${selectedStudentName}`
               : "Data Nilai Siswa"}
           </DialogTitle>
         </DialogHeader>
-        <Card className="shadow-none border-none">
-          <CardHeader className="px-0 pt-0">
-            <div className="flex flex-col md:flex-row justify-between items-start md:items-center space-y-4 md:space-y-0">
-              <div>
-                <CardTitle className="text-lg">
-                  {selectedStudentName
+        <div className="flex-1 overflow-y-auto">
+          <Card className="shadow-none border-none flex flex-col h-full overflow-hidden">
+            <CardHeader className="px-0 pt-0">
+              <div className="flex flex-col md:flex-row justify-between items-start md:items-center space-y-4 md:space-y-0">
+                <div>
+                  <CardTitle className="text-lg">
+                    {selectedStudentName
                     ? `Daftar Nilai ${selectedStudentName}`
                     : "Daftar Nilai Siswa"}
                 </CardTitle>
@@ -178,16 +179,17 @@ const GradesDialog = ({
               </div>
             </div>
           </CardHeader>
-          <CardContent className="px-0">
-            <GradesList
-              loading={loading}
-              grades={filteredGrades}
-              students={students}
-              onVerifyGrade={onVerifyGrade}
-              emptyMessage={emptyMessage}
-            />
-          </CardContent>
-        </Card>
+            <CardContent className="px-0 flex-1 overflow-y-auto pr-1">
+              <GradesList
+                loading={loading}
+                grades={filteredGrades}
+                students={students}
+                onVerifyGrade={onVerifyGrade}
+                emptyMessage={emptyMessage}
+              />
+            </CardContent>
+          </Card>
+        </div>
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
## Summary
- add max-height and overflow handling to the walikelas grade dialog so long lists can scroll
- mirror the scrollable layout for the walikelas attendance dialog to keep dialogs usable on small screens

## Testing
- npm run lint *(fails: pre-existing lint errors in unrelated files about `any` usage)*

------
https://chatgpt.com/codex/tasks/task_e_68f72daf96288332b0e49701598d706e