### PR TITLE
feat: share merged user details across dashboards

### DIFF
--- a/src/components/guru/TeacherAttendanceDialog.tsx
+++ b/src/components/guru/TeacherAttendanceDialog.tsx
@@ -153,11 +153,18 @@ export function TeacherAttendanceDialog({
                     .filter(
                       (s) => String(s.kelasId) === String(attendanceForm.kelasId)
                     )
-                    .map((student) => (
-                      <SelectItem key={student.id} value={String(student.id)}>
-                        {student.nama} ({student.nisn})
-                      </SelectItem>
-                    ))}
+                    .map((student, index) => {
+                      const resolvedStudentId =
+                        student.studentId ?? student.userId ?? student.id;
+                      const optionValue = String(
+                        resolvedStudentId ?? index
+                      );
+                      return (
+                        <SelectItem key={optionValue} value={optionValue}>
+                          {student.nama} ({student.nisn})
+                        </SelectItem>
+                      );
+                    })}
                 </SelectContent>
               </Select>
               <p className="text-xs text-muted-foreground">

--- a/src/components/guru/TeacherDashboardTabs.tsx
+++ b/src/components/guru/TeacherDashboardTabs.tsx
@@ -314,9 +314,13 @@ export function TeacherDashboardTabs({
           <CardContent>
             {students.length > 0 ? (
               <div className="space-y-4">
-                {students.map((student) => (
+                {students.map((student, index) => {
+                  const resolvedStudentId =
+                    student.studentId ?? student.userId ?? student.id;
+                  const identifier = String(resolvedStudentId ?? index);
+                  return (
                   <div
-                    key={student.id}
+                    key={identifier}
                     className="flex items-center justify-between rounded-lg bg-muted/20 p-4 shadow-sm"
                   >
                     <div className="flex items-center space-x-4">
@@ -332,36 +336,37 @@ export function TeacherDashboardTabs({
                       </div>
                     </div>
 
-                    <div className="flex space-x-2">
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => {
-                          setGradeForm((prev) => ({
-                            ...prev,
-                            studentId: String(student.id),
-                          }));
-                          setShowGradeDialog(true);
-                        }}
-                      >
-                        Input Nilai
-                      </Button>
-                      <Button
-                        size="sm"
-                        variant="outline"
-                        onClick={() => {
-                          setAttendanceForm((prev) => ({
-                            ...prev,
-                            studentId: String(student.id),
-                          }));
-                          setShowAttendanceDialog(true);
-                        }}
-                      >
-                        Input Kehadiran
-                      </Button>
-                    </div>
+                        <div className="flex space-x-2">
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => {
+                              setGradeForm((prev) => ({
+                                ...prev,
+                                studentId: identifier,
+                              }));
+                              setShowGradeDialog(true);
+                            }}
+                          >
+                            Input Nilai
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            onClick={() => {
+                              setAttendanceForm((prev) => ({
+                                ...prev,
+                                studentId: identifier,
+                              }));
+                              setShowAttendanceDialog(true);
+                            }}
+                          >
+                            Input Kehadiran
+                          </Button>
+                        </div>
                   </div>
-                ))}
+                );
+                })}
               </div>
             ) : (
               <div className="text-center py-8">

--- a/src/components/guru/TeacherGradeDialog.tsx
+++ b/src/components/guru/TeacherGradeDialog.tsx
@@ -142,11 +142,18 @@ export function TeacherGradeDialog({
                     .filter(
                       (s) => String(s.kelasId) === String(gradeForm.kelasId)
                     )
-                    .map((student) => (
-                      <SelectItem key={student.id} value={String(student.id)}>
-                        {student.nama} ({student.nisn})
-                      </SelectItem>
-                    ))}
+                    .map((student, index) => {
+                      const resolvedStudentId =
+                        student.studentId ?? student.userId ?? student.id;
+                      const optionValue = String(
+                        resolvedStudentId ?? index
+                      );
+                      return (
+                        <SelectItem key={optionValue} value={optionValue}>
+                          {student.nama} ({student.nisn})
+                        </SelectItem>
+                      );
+                    })}
                 </SelectContent>
               </Select>
               <p className="text-xs text-muted-foreground">

--- a/src/components/guru/TeacherStudentListDialog.tsx
+++ b/src/components/guru/TeacherStudentListDialog.tsx
@@ -86,12 +86,18 @@ export function TeacherStudentListDialog({
 
           <div className="space-y-4 max-h-96 overflow-y-auto pr-1">
             {displayedStudents.length > 0 ? (
-              displayedStudents.map((student) => {
+              displayedStudents.map((student, index) => {
                 const kelasName = getClassesName(student.kelasId ?? "");
                 const studentName = student.nama || "Nama tidak tersedia";
 
+                const resolvedStudentId =
+                  student.studentId ?? student.userId ?? student.id;
+
                 return (
-                  <Card key={student.id} className="border border-border">
+                  <Card
+                    key={String(resolvedStudentId ?? index)}
+                    className="border border-border"
+                  >
                     <CardHeader className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
                       <div className="flex items-start gap-3">
                         <div className="p-2 bg-primary/10 rounded-lg">
@@ -139,7 +145,7 @@ export function TeacherStudentListDialog({
                                 : "";
                               setGradeForm((prev) => ({
                                 ...prev,
-                                studentId: String(student.id),
+                                studentId: String(resolvedStudentId ?? ""),
                                 subjectId,
                                 kelasId,
                               }));
@@ -173,7 +179,7 @@ export function TeacherStudentListDialog({
                                 : "";
                               setAttendanceForm((prev) => ({
                                 ...prev,
-                                studentId: String(student.id),
+                                studentId: String(resolvedStudentId ?? ""),
                                 subjectId,
                                 kelasId,
                               }));

--- a/src/components/teacher/AttendanceManagement.tsx
+++ b/src/components/teacher/AttendanceManagement.tsx
@@ -216,11 +216,18 @@ export default function AttendanceManagement({ attendance, students, subjects, c
                       <SelectValue placeholder="Pilih siswa" />
                     </SelectTrigger>
                     <SelectContent>
-                      {students.map((student) => (
-                        <SelectItem key={student.id} value={student.id}>
-                          {student.nama} - {student.nisn || student.nis}
-                        </SelectItem>
-                      ))}
+                      {students.map((student, index) => {
+                        const resolvedStudentId =
+                          student.studentId ?? student.userId ?? student.id;
+                        const optionValue = String(
+                          resolvedStudentId ?? index
+                        );
+                        return (
+                          <SelectItem key={optionValue} value={optionValue}>
+                            {student.nama} - {student.nisn || student.nis}
+                          </SelectItem>
+                        );
+                      })}
                     </SelectContent>
                   </Select>
                 </div>

--- a/src/components/teacher/GradeManagement.tsx
+++ b/src/components/teacher/GradeManagement.tsx
@@ -240,11 +240,18 @@ export default function GradeManagement({ grades, students, subjects, currentUse
                       <SelectValue placeholder="Pilih siswa" />
                     </SelectTrigger>
                     <SelectContent>
-                      {students.map((student) => (
-                        <SelectItem key={student.id} value={student.id}>
-                          {student.nama} - {student.nisn || student.nis}
-                        </SelectItem>
-                      ))}
+                      {students.map((student, index) => {
+                        const resolvedStudentId =
+                          student.studentId ?? student.userId ?? student.id;
+                        const optionValue = String(
+                          resolvedStudentId ?? index
+                        );
+                        return (
+                          <SelectItem key={optionValue} value={optionValue}>
+                            {student.nama} - {student.nisn || student.nis}
+                          </SelectItem>
+                        );
+                      })}
                     </SelectContent>
                   </Select>
                 </div>

--- a/src/components/walikelas/StudentManagement.tsx
+++ b/src/components/walikelas/StudentManagement.tsx
@@ -270,8 +270,12 @@ export default function StudentManagement({ students, currentUser, onDataChange 
             </TableHeader>
             <TableBody>
               {filteredStudents.length > 0 ? (
-                filteredStudents.map((student) => (
-                  <TableRow key={student.id}>
+                filteredStudents.map((student, index) => {
+                  const resolvedStudentId =
+                    student.studentId ?? student.userId ?? student.id;
+                  const rowKey = String(resolvedStudentId ?? index);
+                  return (
+                    <TableRow key={rowKey}>
                     <TableCell className="font-medium">{student.nama}</TableCell>
                     <TableCell>{student.nisn}</TableCell>
                     <TableCell>{student.username}</TableCell>
@@ -288,14 +292,17 @@ export default function StudentManagement({ students, currentUser, onDataChange 
                         <Button
                           size="sm"
                           variant="outline"
-                          onClick={() => handleDeleteStudent(student.id)}
+                          onClick={() =>
+                            handleDeleteStudent(String(resolvedStudentId ?? ""))
+                          }
                         >
                           <Trash2 className="h-4 w-4" />
                         </Button>
                       </div>
                     </TableCell>
-                  </TableRow>
-                ))
+                    </TableRow>
+                  );
+                })
               ) : searchTerm ? (
                 <TableRow>
                   <TableCell colSpan={5} className="text-center py-8 text-muted-foreground">

--- a/src/pages/admin/Dashboard.tsx
+++ b/src/pages/admin/Dashboard.tsx
@@ -3,6 +3,7 @@ import { AdminNavbar } from "@/components/AdminNavbar";
 import { useToast } from "@/hooks/use-toast";
 import apiService from "@/services/apiService";
 import { useIsMobile } from "@/hooks/use-mobile";
+import { mergeUserData } from "@/utils/mergeUserData";
 
 // Import modular components
 import UserManagement from "@/components/admin/UserManagement";
@@ -52,9 +53,9 @@ const AdminDashboard = ({ currentUser, onLogout }) => {
       ]);
 
       const mergedUserForms = mergeUserData(
-        usersData,
-        studentsData,
-        teachersData
+        Array.isArray(usersData) ? usersData : [],
+        Array.isArray(studentsData) ? studentsData : [],
+        Array.isArray(teachersData) ? teachersData : []
       );
 
       setUsers(mergedUserForms);
@@ -73,33 +74,6 @@ const AdminDashboard = ({ currentUser, onLogout }) => {
       setLoading(false);
     }
   }, [toast]);
-
-  const mergeUserData = (usersData, studentsData, teachersData) => {
-    return usersData.map((user) => {
-      const student = studentsData.find((s) => s.userId === user.id);
-      const teacher = teachersData.find((t) => t.userId === user.id);
-
-      return {
-        id: user.id, // gunakan ID dari tabel users
-        username: user.username || "",
-        password: "",
-        email: user.email || "",
-        role: user.role || "",
-
-        nama: user.nama || student?.nama || teacher?.nama || "",
-        nisn: student?.nisn || "",
-        nip: teacher?.nip || user.nip || "",
-        kelasId: student?.kelasId || "",
-        jenisKelamin: student?.jenisKelamin || teacher?.jenisKelamin || "",
-        tanggalLahir: student?.tanggalLahir || "",
-        alamat: student?.alamat || teacher?.alamat || "",
-        nomorHP: student?.nomorHP || teacher?.nomorHP || "",
-        namaOrangTua: student?.namaOrangTua || "",
-        pekerjaanOrangTua: student?.pekerjaanOrangTua || "",
-        tahunMasuk: student?.tahunMasuk || "",
-      };
-    });
-  };
 
   useEffect(() => {
     loadAdminData();

--- a/src/utils/mergeUserData.d.ts
+++ b/src/utils/mergeUserData.d.ts
@@ -1,0 +1,52 @@
+export interface BaseUserRecord {
+  id?: string | number | null;
+  username?: string;
+  email?: string;
+  role?: string;
+  [key: string]: unknown;
+}
+
+export interface StudentRecord {
+  id?: string | number | null;
+  userId?: string | number | null;
+  [key: string]: unknown;
+}
+
+export interface TeacherRecord {
+  id?: string | number | null;
+  userId?: string | number | null;
+  role?: string;
+  [key: string]: unknown;
+}
+
+export interface MergedUserRecord extends BaseUserRecord {
+  id?: string | number | null;
+  userId?: string | number | null;
+  username: string;
+  password: string;
+  email: string;
+  role: string;
+  nama: string;
+  nisn: string;
+  nip: string;
+  kelasId: string | number | null;
+  jenisKelamin: string;
+  tanggalLahir: string;
+  alamat: string;
+  nomorHP: string;
+  namaOrangTua: string;
+  pekerjaanOrangTua: string;
+  tahunMasuk: string;
+  studentId: string | number | null;
+  teacherId: string | number | null;
+  walikelasId: string | number | null;
+  [key: string]: unknown;
+}
+
+export function mergeUserData(
+  users?: BaseUserRecord[],
+  students?: StudentRecord[],
+  teachers?: TeacherRecord[]
+): MergedUserRecord[];
+
+export default mergeUserData;

--- a/src/utils/mergeUserData.js
+++ b/src/utils/mergeUserData.js
@@ -1,0 +1,52 @@
+export function mergeUserData(users = [], students = [], teachers = []) {
+  const studentMap = new Map();
+  const teacherMap = new Map();
+
+  students.forEach((student) => {
+    if (student && student.userId !== undefined && student.userId !== null) {
+      studentMap.set(String(student.userId), student);
+    }
+  });
+
+  teachers.forEach((teacher) => {
+    if (teacher && teacher.userId !== undefined && teacher.userId !== null) {
+      teacherMap.set(String(teacher.userId), teacher);
+    }
+  });
+
+  return users.map((user) => {
+    const userId = user?.id;
+    const userIdKey = userId !== undefined && userId !== null ? String(userId) : null;
+    const student = userIdKey ? studentMap.get(userIdKey) : undefined;
+    const teacher = userIdKey ? teacherMap.get(userIdKey) : undefined;
+
+    const merged = {
+      ...user,
+      id: userId,
+      userId: userId,
+      username: user?.username ?? "",
+      password: "",
+      email: user?.email ?? "",
+      role: teacher?.role ?? student?.role ?? user?.role ?? "",
+      nama: user?.nama ?? student?.nama ?? teacher?.nama ?? "",
+      nisn: student?.nisn ?? "",
+      nip: teacher?.nip ?? user?.nip ?? "",
+      kelasId: student?.kelasId ?? teacher?.kelasId ?? user?.kelasId ?? "",
+      jenisKelamin:
+        user?.jenisKelamin ?? student?.jenisKelamin ?? teacher?.jenisKelamin ?? "",
+      tanggalLahir: student?.tanggalLahir ?? teacher?.tanggalLahir ?? "",
+      alamat: student?.alamat ?? teacher?.alamat ?? user?.alamat ?? "",
+      nomorHP: student?.nomorHP ?? teacher?.nomorHP ?? user?.nomorHP ?? "",
+      namaOrangTua: student?.namaOrangTua ?? "",
+      pekerjaanOrangTua: student?.pekerjaanOrangTua ?? "",
+      tahunMasuk: student?.tahunMasuk ?? "",
+      studentId: student?.id ?? null,
+      teacherId: teacher?.id ?? null,
+      walikelasId: teacher?.walikelasId ?? null,
+    };
+
+    return merged;
+  });
+}
+
+export default mergeUserData;


### PR DESCRIPTION
## Summary
- add a shared mergeUserData helper to combine user, student, and teacher attributes while preserving user ids
- refactor admin, teacher, and walikelas data loaders to rely on merged records and expose both user and domain identifiers
- update teacher and walikelas panels to reference the new ids when selecting or managing students

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68f731d255e88332a127ba7955c11974