### PR TITLE
Align walikelas student gender select with stored codes

### DIFF
--- a/src/components/walikelas/StudentFormDialog.tsx
+++ b/src/components/walikelas/StudentFormDialog.tsx
@@ -136,8 +136,8 @@ const StudentFormDialog = ({
                   <SelectValue placeholder="Pilih jenis kelamin" />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="Laki-laki">Laki-laki</SelectItem>
-                  <SelectItem value="Perempuan">Perempuan</SelectItem>
+                  <SelectItem value="L">Laki-laki</SelectItem>
+                  <SelectItem value="P">Perempuan</SelectItem>
                 </SelectContent>
               </Select>
             </div>


### PR DESCRIPTION
## Summary
- normalize walikelas student gender values from merge data to use the stored L/P codes
- update the student form select options to submit L/P gender codes expected by the backend

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f7373e89a08332b12ce330c44a213e