### PR TITLE
Fix walikelas birth date form to use merged user data

### DIFF
--- a/src/components/walikelas/StudentFormDialog.tsx
+++ b/src/components/walikelas/StudentFormDialog.tsx
@@ -145,7 +145,7 @@ const StudentFormDialog = ({
               <Label>Tanggal Lahir</Label>
               <Input
                 type="date"
-                value={studentForm.tanggalLahir}
+                value={studentForm.tanggalLahir ?? ""}
                 onChange={(e) => onFieldChange("tanggalLahir", e.target.value)}
               />
             </div>

--- a/src/components/walikelas/StudentsSection.tsx
+++ b/src/components/walikelas/StudentsSection.tsx
@@ -23,6 +23,8 @@ interface Student {
   email?: string;
   nomorHP?: string;
   namaOrangTua?: string;
+  tanggalLahir?: string;
+  mergedUserData?: any;
 }
 
 interface StudentsSectionProps {

--- a/src/hooks/use-walikelas-dashboard.ts
+++ b/src/hooks/use-walikelas-dashboard.ts
@@ -143,7 +143,8 @@ const useWalikelasDashboard = (currentUser: CurrentUser | null) => {
   const updateStudentForm = useCallback((field: string, value: string) => {
     setStudentForm((prev) => ({
       ...prev,
-      [field]: value,
+      [field]:
+        field === "tanggalLahir" ? normalizeDateValue(value) : value,
     }));
   }, []);
 
@@ -153,9 +154,16 @@ const useWalikelasDashboard = (currentUser: CurrentUser | null) => {
   }, [clearStudentForm]);
 
   const editStudent = useCallback((student: any) => {
+    const mergedRecord = student?.mergedUserData ?? null;
+    const resolvedTanggalLahir = normalizeDateValue(
+      mergedRecord?.tanggalLahir ?? student?.tanggalLahir
+    );
+
     setStudentForm({
       ...createDefaultStudentForm(),
+      ...(mergedRecord ?? {}),
       ...student,
+      tanggalLahir: resolvedTanggalLahir,
     });
     setEditingStudent(student);
     setShowStudentDialog(true);
@@ -412,6 +420,12 @@ const useWalikelasDashboard = (currentUser: CurrentUser | null) => {
             ...record,
           };
 
+          const resolvedTanggalLahir = normalizeDateValue(
+            record?.tanggalLahir ??
+              classStudent?.tanggalLahir ??
+              mergedStudent?.tanggalLahir
+          );
+
           normalizedStudentsMap.set(key, {
             ...mergedStudent,
             id: record?.userId ?? record?.id ?? key,
@@ -427,7 +441,8 @@ const useWalikelasDashboard = (currentUser: CurrentUser | null) => {
               mergedStudent?.kelasId ??
               null,
             jenisKelamin: normalizeGender(mergedStudent?.jenisKelamin),
-            tanggalLahir: normalizeDateValue(mergedStudent?.tanggalLahir),
+            tanggalLahir: resolvedTanggalLahir,
+            mergedUserData: record,
           });
         });
 
@@ -445,6 +460,7 @@ const useWalikelasDashboard = (currentUser: CurrentUser | null) => {
               ...fallbackStudent,
               jenisKelamin: normalizeGender(fallbackStudent?.jenisKelamin),
               tanggalLahir: normalizeDateValue(fallbackStudent?.tanggalLahir),
+              mergedUserData: null,
             });
           }
         });


### PR DESCRIPTION
## Summary
- normalize birth date updates in the walikelas dashboard form and reuse mergeUserData values when editing students
- persist merged user data alongside student entries so the edit dialog can prefill their birth dates reliably
- guard the birth date input against undefined values to avoid empty or invalid date states

## Testing
- Not run

------
https://chatgpt.com/codex/tasks/task_e_68f73997fae48332998f03c58444d44e