### PR TITLE
Add dark borders to table headers and cells

### DIFF
--- a/src/components/ui/table.tsx
+++ b/src/components/ui/table.tsx
@@ -73,7 +73,7 @@ const TableHead = React.forwardRef<
   <th
     ref={ref}
     className={cn(
-      "h-12 px-4 text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
+      "h-12 border border-slate-300 px-4 text-left align-middle font-medium text-muted-foreground dark:border-slate-700 [&:has([role=checkbox])]:pr-0",
       className
     )}
     {...props}
@@ -87,7 +87,10 @@ const TableCell = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <td
     ref={ref}
-    className={cn("p-4 align-middle [&:has([role=checkbox])]:pr-0", className)}
+    className={cn(
+      "border border-slate-300 p-4 align-middle dark:border-slate-700 [&:has([role=checkbox])]:pr-0",
+      className
+    )}
     {...props}
   />
 ))


### PR DESCRIPTION
## Summary
- add consistent dark border styling for reusable table header and cell components

## Testing
- npm run lint *(fails: existing lint errors about explicit any types and other unrelated lint rules)*

------
https://chatgpt.com/codex/tasks/task_e_68fb8200e14c8332aad685a92d53d46b