### PR TITLE
Fix walikelas student data loading

### DIFF
--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -1386,10 +1386,10 @@ const apiService = {
   },
 
   // ============= WALIKELAS METHODS =============
-  async getClassStudents(classId) {
+  async getClassStudents(walikelasId) {
     if (USE_API) {
       const response = await this.authFetch(
-        `${API_BASE_URL}/walikelas/${classId}/kelas/siswa`
+        `${API_BASE_URL}/walikelas/${walikelasId}/kelas/siswa`
       );
       return normalizeData(response.data);
     } else {


### PR DESCRIPTION
## Summary
- ensure walikelas dashboard data requests use the logged-in walikelas identifier
- guard against missing walikelas IDs and improve class detection fallback logic
- align the class student API helper with the walikelas-scoped endpoint parameter

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68fe67503008833283f9b98b33f87c7f