### PR TITLE
Fix walikelas dashboard to prefer teacherId

### DIFF
--- a/src/hooks/use-walikelas-dashboard.ts
+++ b/src/hooks/use-walikelas-dashboard.ts
@@ -317,7 +317,8 @@ const useWalikelasDashboard = (currentUser: CurrentUser | null) => {
           return;
         }
 
-        const walikelasId = currentUser?.id ?? currentUser?.walikelasId;
+        const walikelasId =
+          currentUser?.teacherId ?? currentUser?.walikelasId ?? currentUser?.id;
 
         if (!walikelasId) {
           console.warn(


### PR DESCRIPTION
## Summary
- ensure the walikelas dashboard resolves the walikelas ID from the current user's teacherId before falling back to other identifiers

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fe72401d5c833294f740053fe2902c