### PR TITLE
Align walikelas class assignment with teacher IDs

### DIFF
--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -1322,8 +1322,23 @@ const apiService = {
       const classes = JSON.parse(
         localStorage.getItem(STORAGE_KEYS.CLASSES) || "[]"
       );
+      const {
+        walikelasTeacherId = null,
+        walikelasId: walikelasUserId = null,
+        ...restClassData
+      } = classData || {};
+      const walikelasReferenceId =
+        walikelasTeacherId !== undefined && walikelasTeacherId !== null
+          ? walikelasTeacherId
+          : walikelasUserId;
+
       const newClass = {
-        ...classData,
+        ...restClassData,
+        walikelasId:
+          walikelasReferenceId !== undefined ? walikelasReferenceId : null,
+        walikelasTeacherId:
+          walikelasTeacherId !== undefined ? walikelasTeacherId : null,
+        walikelasUserId,
         id: Date.now().toString(),
         createdAt: new Date().toISOString(),
       };
@@ -1351,9 +1366,24 @@ const apiService = {
       const classIndex = classes.findIndex((c) => c.id === classId);
 
       if (classIndex !== -1) {
+        const {
+          walikelasTeacherId = null,
+          walikelasId: walikelasUserId = null,
+          ...restClassData
+        } = classData || {};
+        const walikelasReferenceId =
+          walikelasTeacherId !== undefined && walikelasTeacherId !== null
+            ? walikelasTeacherId
+            : walikelasUserId;
+
         classes[classIndex] = {
           ...classes[classIndex],
-          ...classData,
+          ...restClassData,
+          walikelasId:
+            walikelasReferenceId !== undefined ? walikelasReferenceId : null,
+          walikelasTeacherId:
+            walikelasTeacherId !== undefined ? walikelasTeacherId : null,
+          walikelasUserId,
           updatedAt: new Date().toISOString(),
         };
         localStorage.setItem(STORAGE_KEYS.CLASSES, JSON.stringify(classes));


### PR DESCRIPTION
## Summary
- update the admin class management form to load and display wali kelas selections by teacherId while translating the choice to a userId when building the API payload
- ensure class editing keeps the teacher mapping intact and resolve wali kelas names from either teacher or user identifiers
- adjust local API fallbacks to persist teacherId-backed wali kelas references alongside the originating userId

## Testing
- npm run lint *(fails: existing lint errors around any usage and react-refresh warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68fe7b7147908332934127c90b71065c