### PR TITLE
Fix teacher ID usage in grade and attendance flows

### DIFF
--- a/src/components/teacher/AttendanceManagement.tsx
+++ b/src/components/teacher/AttendanceManagement.tsx
@@ -67,11 +67,20 @@ export default function AttendanceManagement({ attendance, students, subjects, c
     }
 
     try {
+      if (!currentUser?.teacherId) {
+        toast({
+          title: "Error",
+          description: "ID guru tidak ditemukan. Harap hubungi administrator.",
+          variant: "destructive"
+        });
+        return;
+      }
+
       const studentData = students.find(s => s.id === attendanceForm.studentId);
       const attendanceData = {
         id: editingAttendance ? editingAttendance.id : Date.now().toString(),
         ...attendanceForm,
-        teacherId: currentUser.id,
+        teacherId: currentUser.teacherId,
         kelasId: studentData?.kelasId || '1',
         tahunAjaran: '2024/2025',
         semester: 1
@@ -90,7 +99,7 @@ export default function AttendanceManagement({ attendance, students, subjects, c
           result = { success: false, message: "Attendance not found" };
         }
       } else {
-        result = await apiService.addAttendance(currentUser.id, attendanceData);
+        result = await apiService.addAttendance(currentUser.teacherId, attendanceData);
       }
       
       if (result.success) {

--- a/src/components/teacher/GradeManagement.tsx
+++ b/src/components/teacher/GradeManagement.tsx
@@ -89,11 +89,20 @@ export default function GradeManagement({ grades, students, subjects, currentUse
     }
 
     try {
+      if (!currentUser?.teacherId) {
+        toast({
+          title: "Error",
+          description: "ID guru tidak ditemukan. Harap hubungi administrator.",
+          variant: "destructive"
+        });
+        return;
+      }
+
       const studentData = students.find(s => s.id === gradeForm.studentId);
       const gradeData = {
         id: editingGrade ? editingGrade.id : Date.now().toString(),
         ...gradeForm,
-        teacherId: currentUser.id,
+        teacherId: currentUser.teacherId,
         kelasId: studentData?.kelasId || '1',
         tahunAjaran: '2024/2025',
         semester: 1,
@@ -114,7 +123,7 @@ export default function GradeManagement({ grades, students, subjects, currentUse
           result = { success: false, message: "Grade not found" };
         }
       } else {
-        result = await apiService.addGrade(currentUser.id, gradeData);
+        result = await apiService.addGrade(currentUser.teacherId, gradeData);
       }
       
       if (result.success) {


### PR DESCRIPTION
## Summary
- ensure grade submissions use `currentUser.teacherId` and stop submission when the ID is missing
- mirror the teacher ID guard and usage for attendance submissions

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68feff53615083328e064f7b0cf65703