### PR TITLE
Enforce walikelas teacherId usage across dashboard workflows

### DIFF
--- a/src/components/walikelas/GradeVerification.tsx
+++ b/src/components/walikelas/GradeVerification.tsx
@@ -21,7 +21,18 @@ export default function GradeVerification({ grades, students, currentUser, onDat
 
   const handleVerifyGrade = async (gradeId: string) => {
     try {
-      const result = await apiService.verifyGrade(currentUser.id, gradeId);
+      const teacherId = currentUser?.teacherId;
+      if (!teacherId) {
+        toast({
+          title: "Data Wali Kelas",
+          description:
+            "ID wali kelas tidak ditemukan pada akun Anda. Hubungi admin untuk bantuan lebih lanjut.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      const result = await apiService.verifyGrade(teacherId, gradeId);
       if (result.success) {
         toast({
           title: "Berhasil",
@@ -50,9 +61,20 @@ export default function GradeVerification({ grades, students, currentUser, onDat
     ) {
       setLoading(true);
       try {
+        const teacherId = currentUser?.teacherId;
+        if (!teacherId) {
+          toast({
+            title: "Data Wali Kelas",
+            description:
+              "ID wali kelas tidak ditemukan pada akun Anda. Hubungi admin untuk bantuan lebih lanjut.",
+            variant: "destructive",
+          });
+          return;
+        }
+
         // Verify all unverified grades
         const verifyPromises = unverifiedGrades.map((grade) =>
-          apiService.verifyGrade(currentUser.id, grade.id)
+          apiService.verifyGrade(teacherId, grade.id)
         );
 
         await Promise.all(verifyPromises);

--- a/src/components/walikelas/StudentManagement.tsx
+++ b/src/components/walikelas/StudentManagement.tsx
@@ -50,6 +50,17 @@ export default function StudentManagement({ students, currentUser, onDataChange 
     }
 
     try {
+      const teacherId = currentUser?.teacherId;
+      if (!teacherId) {
+        toast({
+          title: "Data Wali Kelas",
+          description:
+            "ID wali kelas tidak ditemukan pada akun Anda. Hubungi admin untuk bantuan lebih lanjut.",
+          variant: "destructive",
+        });
+        return;
+      }
+
       const studentData = {
         ...studentForm,
         id: editingStudent ? editingStudent.id : Date.now().toString(),
@@ -60,12 +71,12 @@ export default function StudentManagement({ students, currentUser, onDataChange 
       let result;
       if (editingStudent) {
         result = await apiService.updateClassStudent(
-          currentUser.id,
+          teacherId,
           studentData.id,
           studentData
         );
       } else {
-        result = await apiService.addClassStudent(currentUser.id, studentData);
+        result = await apiService.addClassStudent(teacherId, studentData);
       }
 
       if (result.success) {
@@ -93,8 +104,19 @@ export default function StudentManagement({ students, currentUser, onDataChange 
   const handleDeleteStudent = async (studentId: string) => {
     if (window.confirm("Apakah Anda yakin ingin menghapus siswa ini?")) {
       try {
+        const teacherId = currentUser?.teacherId;
+        if (!teacherId) {
+          toast({
+            title: "Data Wali Kelas",
+            description:
+              "ID wali kelas tidak ditemukan pada akun Anda. Hubungi admin untuk bantuan lebih lanjut.",
+            variant: "destructive",
+          });
+          return;
+        }
+
         const result = await apiService.deleteClassStudent(
-          currentUser.id,
+          teacherId,
           studentId
         );
         if (result.success) {


### PR DESCRIPTION
## Summary
- require the walikelas dashboard data loader to rely solely on the teacherId and surface an error when it is missing
- guard student management and grade verification actions in the dashboard hook with teacherId checks before calling APIs
- update walikelas student management and grade verification components to call the API with the teacherId

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ff008875ec833285e6aedfd64938cd