### PR TITLE
Normalize wali kelas student ID lookups

### DIFF
--- a/src/components/walikelas/AttendanceList.tsx
+++ b/src/components/walikelas/AttendanceList.tsx
@@ -14,6 +14,8 @@ interface AttendanceRecord {
 interface StudentSummary {
   id: string;
   nama: string;
+  studentId?: string | number | null;
+  userId?: string | number | null;
 }
 
 interface AttendanceListProps {
@@ -27,8 +29,40 @@ const AttendanceList = ({
   students,
   emptyMessage,
 }: AttendanceListProps) => {
-  const findStudentName = (studentId: string) =>
-    students.find((student) => student.id === studentId)?.nama || "Siswa";
+  const matchStudentById = (
+    studentId: string | number | null | undefined
+  ) => {
+    if (studentId === undefined || studentId === null) {
+      return undefined;
+    }
+
+    const targetId = String(studentId);
+
+    return students.find((student) => {
+      const candidateIds = [
+        student.studentId ?? student.id ?? student.userId,
+        student.studentId,
+        student.id,
+        student.userId,
+      ]
+        .filter((value) => value !== undefined && value !== null)
+        .map((value) => String(value));
+
+      return candidateIds.includes(targetId);
+    });
+  };
+
+  const getNormalizedStudentId = (studentId: string | number) => {
+    const student = matchStudentById(studentId);
+    const normalizedId = student?.studentId ?? student?.id ?? student?.userId;
+
+    return normalizedId !== undefined && normalizedId !== null
+      ? String(normalizedId)
+      : studentId;
+  };
+
+  const findStudentName = (studentId: string | number | null | undefined) =>
+    matchStudentById(studentId)?.nama || "Siswa";
 
   if (attendance.length === 0) {
     return (
@@ -44,6 +78,7 @@ const AttendanceList = ({
   return (
     <div className="space-y-4">
       {attendance.map((record) => {
+        const normalizedStudentId = getNormalizedStudentId(record.studentId);
         const status = getAttendanceStatus(record.status);
 
         return (
@@ -53,7 +88,7 @@ const AttendanceList = ({
           >
             <div className="flex-1">
               <h4 className="font-medium text-foreground">
-                {findStudentName(record.studentId)}
+                {findStudentName(normalizedStudentId)}
               </h4>
               <div className="flex flex-wrap items-center gap-2 mt-1">
                 <Badge variant="outline" className="text-xs">

--- a/src/components/walikelas/GradeVerification.tsx
+++ b/src/components/walikelas/GradeVerification.tsx
@@ -97,8 +97,33 @@ export default function GradeVerification({ grades, students, currentUser, onDat
     }
   };
 
-  const getStudentName = (studentId: string) => {
-    const student = students.find(s => s.id === studentId);
+  const matchStudentById = (
+    studentId: string | number | null | undefined
+  ) => {
+    if (studentId === undefined || studentId === null) {
+      return undefined;
+    }
+
+    const targetId = String(studentId);
+
+    return students.find((student) => {
+      const candidateIds = [
+        student?.studentId ?? student?.id ?? student?.userId,
+        student?.studentId,
+        student?.id,
+        student?.userId,
+      ]
+        .filter((value) => value !== undefined && value !== null)
+        .map((value) => String(value));
+
+      return candidateIds.includes(targetId);
+    });
+  };
+
+  const getStudentName = (
+    studentId: string | number | null | undefined
+  ) => {
+    const student = matchStudentById(studentId);
     return student?.nama || 'Unknown Student';
   };
 

--- a/src/components/walikelas/ReportsSection.tsx
+++ b/src/components/walikelas/ReportsSection.tsx
@@ -7,6 +7,8 @@ interface StudentReportCandidate {
   id: string;
   nama: string;
   nisn: string;
+  studentId?: string | number | null;
+  userId?: string | number | null;
 }
 
 interface GradeItem {
@@ -36,9 +38,25 @@ const ReportsSection = ({
   onPrintReport,
 }: ReportsSectionProps) => {
   const renderStudentCard = (student: StudentReportCandidate) => {
-    const studentGrades = grades.filter(
-      (grade) => grade.studentId === student.id && grade.verified
-    );
+    const matchGradeToStudent = (grade: GradeItem) => {
+      if (grade.studentId === undefined || grade.studentId === null) {
+        return false;
+      }
+
+      const targetId = String(grade.studentId);
+      const candidateIds = [
+        student.studentId ?? student.id ?? student.userId,
+        student.studentId,
+        student.id,
+        student.userId,
+      ]
+        .filter((value) => value !== undefined && value !== null)
+        .map((value) => String(value));
+
+      return grade.verified && candidateIds.includes(targetId);
+    };
+
+    const studentGrades = grades.filter(matchGradeToStudent);
     const verifiedSubjects = studentGrades.length;
     const averageGrade =
       studentGrades.length > 0


### PR DESCRIPTION
## Summary
- normalize student matching in wali kelas grade and attendance lists so names and aria labels resolve across multiple identifier fields
- align report aggregation to use the same normalized identifiers when counting verified subjects and calculating averages
- update grade verification to resolve student names via the normalized identifier set

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_6900ed117b6083329544e27dd2e1857b