### PR TITLE
Normalize student identifier for class report printing

### DIFF
--- a/src/hooks/use-walikelas-dashboard.ts
+++ b/src/hooks/use-walikelas-dashboard.ts
@@ -976,9 +976,22 @@ const useWalikelasDashboard = (currentUser: CurrentUser | null) => {
           return;
         }
 
+        const normalizedStudentId = String(
+          student?.studentId ?? student?.id ?? student?.userId ?? ""
+        ).trim();
+
+        if (!normalizedStudentId) {
+          toast({
+            title: "Error",
+            description: "ID siswa tidak ditemukan",
+            variant: "destructive",
+          });
+          return;
+        }
+
         const reportData = await apiService.getClassStudentReport(
           walikelasId,
-          student.id,
+          normalizedStudentId,
           null,
           null,
           requestSemesterId


### PR DESCRIPTION
## Summary
- normalize the student identifier used when fetching report data by checking multiple fields
- add a guard that notifies the user if the student ID cannot be resolved before printing the report

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6900f1a7bb1c8332bae605b597d6a741