### PR TITLE
Use studentId for student dashboard data loading

### DIFF
--- a/src/hooks/use-student-dashboard.test.tsx
+++ b/src/hooks/use-student-dashboard.test.tsx
@@ -48,10 +48,12 @@ const relaxedSettings = {
   activeSemester: mockSemesters[0],
 };
 
+const baseCurrentUser = { id: 1, studentId: 42, nama: "Budi" } as const;
+
 const mockGrades = [
   {
     id: 1,
-    studentId: 1,
+    studentId: 42,
     kelasId: 1,
     subjectId: 10,
     teacherId: 99,
@@ -88,7 +90,7 @@ describe("useStudentDashboard", () => {
     vi.mocked(apiService.getStudentAttendance).mockResolvedValue(mockAttendance);
 
     const { result } = renderHook(() =>
-      useStudentDashboard({ currentUser: { id: 1, nama: "Budi" } })
+      useStudentDashboard({ currentUser: baseCurrentUser })
     );
 
     await waitFor(() => expect(result.current.grades).toHaveLength(1));
@@ -96,6 +98,37 @@ describe("useStudentDashboard", () => {
     expect(result.current.selectedSemesterId).toBe("1");
     expect(result.current.averageGrade).toBe(90);
     expect(result.current.attendanceStats.hadir).toBe(1);
+  });
+
+  it("uses studentId from the authenticated user when fetching data", async () => {
+    vi.mocked(apiService.getSemesters).mockResolvedValue(mockSemesters);
+    vi.mocked(apiService.getStudentGrades).mockResolvedValue(mockGrades);
+    vi.mocked(apiService.getStudentAttendance).mockResolvedValue(mockAttendance);
+
+    renderHook(() => useStudentDashboard({ currentUser: baseCurrentUser }));
+
+    await waitFor(() =>
+      expect(apiService.getStudentGrades).toHaveBeenCalledTimes(1)
+    );
+
+    const [calledStudentId] = vi.mocked(apiService.getStudentGrades).mock.calls[0];
+    expect(calledStudentId).toBe(baseCurrentUser.studentId);
+  });
+
+  it("falls back to user id when studentId is unavailable", async () => {
+    const fallbackUser = { id: 7, nama: "Budi" } as const;
+    vi.mocked(apiService.getSemesters).mockResolvedValue(mockSemesters);
+    vi.mocked(apiService.getStudentGrades).mockResolvedValue(mockGrades);
+    vi.mocked(apiService.getStudentAttendance).mockResolvedValue(mockAttendance);
+
+    renderHook(() => useStudentDashboard({ currentUser: fallbackUser }));
+
+    await waitFor(() =>
+      expect(apiService.getStudentGrades).toHaveBeenCalledTimes(1)
+    );
+
+    const [calledStudentId] = vi.mocked(apiService.getStudentGrades).mock.calls[0];
+    expect(calledStudentId).toBe(fallbackUser.id);
   });
 
   it("mengirim semesterId hanya ketika mode strict aktif", async () => {
@@ -116,9 +149,7 @@ describe("useStudentDashboard", () => {
     vi.mocked(apiService.getStudentGrades).mockResolvedValue(mockGrades);
     vi.mocked(apiService.getStudentAttendance).mockResolvedValue(mockAttendance);
 
-    renderHook(() =>
-      useStudentDashboard({ currentUser: { id: 1, nama: "Budi" } })
-    );
+    renderHook(() => useStudentDashboard({ currentUser: baseCurrentUser }));
 
     await waitFor(() =>
       expect(apiService.getStudentGrades).toHaveBeenCalledTimes(1)
@@ -136,9 +167,7 @@ describe("useStudentDashboard", () => {
     vi.mocked(apiService.getStudentGrades).mockClear();
     vi.mocked(apiService.getStudentAttendance).mockClear();
 
-    renderHook(() =>
-      useStudentDashboard({ currentUser: { id: 1, nama: "Budi" } })
-    );
+    renderHook(() => useStudentDashboard({ currentUser: baseCurrentUser }));
 
     await waitFor(() =>
       expect(apiService.getStudentGrades).toHaveBeenCalledTimes(1)
@@ -166,7 +195,7 @@ describe("useStudentDashboard", () => {
     vi.mocked(apiService.getStudentAttendance).mockResolvedValue(mockAttendance);
 
     const { result } = renderHook(() =>
-      useStudentDashboard({ currentUser: { id: 1, nama: "Budi" } })
+      useStudentDashboard({ currentUser: baseCurrentUser })
     );
 
     await waitFor(() => expect(result.current.semesterWarning).not.toBe(""));
@@ -193,7 +222,7 @@ describe("useStudentDashboard", () => {
     });
 
     const { result } = renderHook(() =>
-      useStudentDashboard({ currentUser: { id: 1, nama: "Budi" } })
+      useStudentDashboard({ currentUser: baseCurrentUser })
     );
 
     await waitFor(() => expect(result.current.selectedSemesterId).toBe("1"));
@@ -217,7 +246,7 @@ describe("useStudentDashboard", () => {
     vi.mocked(apiService.getStudentAttendance).mockResolvedValue(mockAttendance);
 
     const { result } = renderHook(() =>
-      useStudentDashboard({ currentUser: { id: 1, nama: "Budi" } })
+      useStudentDashboard({ currentUser: baseCurrentUser })
     );
 
     await waitFor(() =>
@@ -243,7 +272,7 @@ describe("useStudentDashboard", () => {
     vi.mocked(apiService.getStudentAttendance).mockResolvedValue(mockAttendance);
 
     const { result } = renderHook(() =>
-      useStudentDashboard({ currentUser: { id: 1, nama: "Budi" } })
+      useStudentDashboard({ currentUser: baseCurrentUser })
     );
 
     await waitFor(() =>
@@ -270,7 +299,7 @@ describe("useStudentDashboard", () => {
     vi.mocked(apiService.getStudentReport).mockRejectedValue(error);
 
     const { result } = renderHook(() =>
-      useStudentDashboard({ currentUser: { id: 1, nama: "Budi" } })
+      useStudentDashboard({ currentUser: baseCurrentUser })
     );
 
     await waitFor(() => expect(result.current.selectedSemesterId).toBe("1"));

--- a/src/hooks/use-student-dashboard.ts
+++ b/src/hooks/use-student-dashboard.ts
@@ -15,6 +15,7 @@ import {
 
 export interface StudentUser {
   id: number | string;
+  studentId?: number | string | null;
   nama?: string;
   [key: string]: unknown;
 }
@@ -71,7 +72,7 @@ export const useStudentDashboard = ({
   currentUser,
 }: UseStudentDashboardParams) => {
   const { toast } = useToast();
-  const userId = currentUser?.id ?? null;
+  const studentId = currentUser?.studentId ?? currentUser?.id ?? null;
 
   const [grades, setGrades] = useState<StudentGrade[]>([]);
   const [attendance, setAttendance] = useState<StudentAttendanceRecord[]>([]);
@@ -139,7 +140,7 @@ export const useStudentDashboard = ({
   );
 
   const loadSemesters = useCallback(async () => {
-    if (!userId) return;
+    if (!studentId) return;
 
     try {
       const semestersResponse = await apiService.getSemesters();
@@ -190,12 +191,12 @@ export const useStudentDashboard = ({
     normalizeSemesterMetadata,
     selectedSemesterId,
     toast,
-    userId,
+    studentId,
   ]);
 
   const loadStudentData = useCallback(
     async (semesterIdParam?: string | null) => {
-      if (!userId) return;
+      if (!studentId) return;
 
       if (enforcementLoading) {
         return;
@@ -279,13 +280,13 @@ export const useStudentDashboard = ({
 
         const [gradesResponse, attendanceResponse] = await Promise.all([
           apiService.getStudentGrades(
-            userId,
+            studentId,
             tahunParam,
             semesterNumberParam,
             requestSemesterId
           ),
           apiService.getStudentAttendance(
-            userId,
+            studentId,
             tahunParam,
             semesterNumberParam,
             requestSemesterId
@@ -393,12 +394,12 @@ export const useStudentDashboard = ({
       semesters,
       shouldAttachSemesterId,
       toast,
-      userId,
+      studentId,
     ]
   );
 
   const handlePrintReport = useCallback(async () => {
-    if (!userId) return;
+    if (!studentId) return;
 
     const hasSemesters = semesters.length > 0;
     const effectiveSemesterId = hasSemesters
@@ -422,7 +423,7 @@ export const useStudentDashboard = ({
         : null;
 
       const reportData = await apiService.getStudentReport(
-        userId,
+        studentId,
         metadata?.tahunAjaran ?? null,
         metadata?.semesterNumber ?? null,
         effectiveSemesterId || null
@@ -503,7 +504,13 @@ export const useStudentDashboard = ({
         variant: "destructive",
       });
     }
-  }, [getEffectiveSemesterId, resolveSemesterMetadata, semesters, toast, userId]);
+  }, [
+    getEffectiveSemesterId,
+    resolveSemesterMetadata,
+    semesters,
+    toast,
+    studentId,
+  ]);
 
   const handleSemesterChange = useCallback(
     (semesterId: string) => {
@@ -516,17 +523,17 @@ export const useStudentDashboard = ({
   );
 
   useEffect(() => {
-    if (!userId) return;
+    if (!studentId) return;
     loadSemesters();
-  }, [loadSemesters, userId]);
+  }, [loadSemesters, studentId]);
 
   useEffect(() => {
-    if (!userId) return;
+    if (!studentId) return;
     const shouldLoadWithoutSemester = semesters.length === 0;
     if (shouldLoadWithoutSemester || selectedSemesterId) {
       loadStudentData();
     }
-  }, [loadStudentData, selectedSemesterId, semesters.length, userId]);
+  }, [loadStudentData, selectedSemesterId, semesters.length, studentId]);
 
   useEffect(() => {
     if (enforcementLoading) {


### PR DESCRIPTION
## Summary
- prefer the studentId returned at login when loading dashboard data and reports for students
- retain a fallback to the user id and update hook dependencies to match the new identifier
- expand the useStudentDashboard tests to cover studentId usage and the fallback path

## Testing
- npm test -- --run src/hooks/use-student-dashboard.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_690376371fe0833282b244d2d8638c80