### PR TITLE
Add report search for walikelas reports section

### DIFF
--- a/src/components/walikelas/ReportsSection.test.tsx
+++ b/src/components/walikelas/ReportsSection.test.tsx
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import ReportsSection from "./ReportsSection";
+
+const baseProps = {
+  students: [
+    {
+      id: "1",
+      nama: "John Doe",
+      nis: "1001",
+      nisn: "12345",
+    },
+    {
+      id: "2",
+      nama: "Jane Smith",
+      nis: "1002",
+      nisn: "67890",
+    },
+  ],
+  grades: [
+    { studentId: "1", nilai: "80", verified: true },
+    { studentId: "1", nilai: "90", verified: true },
+  ],
+  selectedSemesterPeriodLabel: "Semester Ganjil 2024/2025",
+  selectedSemesterDateRange: "1 Juli 2024 - 31 Desember 2024",
+  selectedSemesterMetadata: {
+    jumlahHariBelajar: 120,
+    catatan: "Catatan semester",
+  },
+  onPrintReport: vi.fn(),
+  searchTerm: "",
+  onSearchChange: vi.fn(),
+} as const;
+
+describe("ReportsSection", () => {
+  it("menampilkan daftar siswa siap cetak", () => {
+    render(<ReportsSection {...baseProps} />);
+
+    expect(
+      screen.getByRole("heading", { name: "Laporan Raport Siswa" })
+    ).toBeInTheDocument();
+    expect(screen.getAllByText(/Semester Ganjil 2024\/2025/i).length).toBeGreaterThan(0);
+    expect(screen.getByText("John Doe")).toBeInTheDocument();
+    expect(screen.getByText("Jane Smith")).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText(
+        "Cari siswa berdasarkan nama, NIS, atau NISN..."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("memicu handler pencarian ketika nilai berubah", () => {
+    const onSearchChange = vi.fn();
+    render(<ReportsSection {...baseProps} onSearchChange={onSearchChange} />);
+
+    fireEvent.change(screen.getByLabelText(/Cari siswa untuk raport/i), {
+      target: { value: "jane" },
+    });
+
+    expect(onSearchChange).toHaveBeenCalledWith("jane");
+  });
+
+  it("menampilkan pesan kosong ketika tidak ada siswa", () => {
+    render(<ReportsSection {...baseProps} students={[]} />);
+
+    expect(
+      screen.getByText("Belum Ada Siswa dengan Nilai Terverifikasi")
+    ).toBeInTheDocument();
+  });
+
+  it("memicu cetak raport saat tombol diklik", () => {
+    const onPrintReport = vi.fn();
+    render(<ReportsSection {...baseProps} onPrintReport={onPrintReport} />);
+
+    fireEvent.click(screen.getAllByRole("button", { name: /Cetak Raport/i })[0]);
+
+    expect(onPrintReport).toHaveBeenCalledWith(baseProps.students[0]);
+  });
+});

--- a/src/components/walikelas/ReportsSection.tsx
+++ b/src/components/walikelas/ReportsSection.tsx
@@ -1,7 +1,9 @@
+import type { ChangeEvent } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { FileText, Printer } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { FileText, Printer, Search } from "lucide-react";
 
 interface StudentReportCandidate {
   id: string;
@@ -28,6 +30,8 @@ interface ReportsSectionProps {
     catatan?: string | null;
   } | null;
   onPrintReport: (student: StudentReportCandidate) => void;
+  searchTerm: string;
+  onSearchChange: (value: string) => void;
 }
 
 const ReportsSection = ({
@@ -37,7 +41,13 @@ const ReportsSection = ({
   selectedSemesterDateRange,
   selectedSemesterMetadata,
   onPrintReport,
+  searchTerm,
+  onSearchChange,
 }: ReportsSectionProps) => {
+  const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onSearchChange(event.target.value);
+  };
+
   const renderStudentCard = (student: StudentReportCandidate) => {
     const matchGradeToStudent = (grade: GradeItem) => {
       if (grade.studentId === undefined || grade.studentId === null) {
@@ -151,9 +161,21 @@ const ReportsSection = ({
               </div>
             )}
           </div>
-          <div className="text-sm text-muted-foreground">
-            <span className="font-medium">{students.length}</span> siswa siap
-            cetak raport
+          <div className="flex flex-col w-full md:w-auto gap-2">
+            <div className="relative w-full md:w-72">
+              <Search className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
+              <Input
+                value={searchTerm}
+                onChange={handleSearchChange}
+                placeholder="Cari siswa berdasarkan nama, NIS, atau NISN..."
+                aria-label="Cari siswa untuk raport"
+                className="pl-9"
+              />
+            </div>
+            <div className="text-sm text-muted-foreground md:text-right">
+              <span className="font-medium">{students.length}</span> siswa siap
+              cetak raport
+            </div>
           </div>
         </div>
       </CardHeader>

--- a/src/hooks/use-walikelas-dashboard.ts
+++ b/src/hooks/use-walikelas-dashboard.ts
@@ -161,6 +161,7 @@ const useWalikelasDashboard = (currentUser: CurrentUser | null) => {
   const [showStudentDialog, setShowStudentDialog] = useState(false);
   const [editingStudent, setEditingStudent] = useState<any>(null);
   const [searchTerm, setSearchTerm] = useState("");
+  const [reportSearchTerm, setReportSearchTerm] = useState("");
   const [activeSection, setActiveSection] = useState("students");
   const [semesters, setSemesters] = useState<DashboardSemesterRecord[]>([]);
   const [selectedSemesterId, setSelectedSemesterId] = useState<string>("");
@@ -1120,6 +1121,26 @@ const useWalikelasDashboard = (currentUser: CurrentUser | null) => {
     [grades, students]
   );
 
+  const filteredReportStudents = useMemo(() => {
+    const normalizedSearch = reportSearchTerm.trim().toLowerCase();
+
+    if (!normalizedSearch) {
+      return studentsWithVerifiedGrades;
+    }
+
+    return studentsWithVerifiedGrades.filter((student) => {
+      const name = (student.nama ?? "").toLowerCase();
+      const nis = (student.nis ?? "").toLowerCase();
+      const nisn = (student.nisn ?? "").toLowerCase();
+
+      return (
+        name.includes(normalizedSearch) ||
+        nis.includes(normalizedSearch) ||
+        nisn.includes(normalizedSearch)
+      );
+    });
+  }, [reportSearchTerm, studentsWithVerifiedGrades]);
+
   const handleStudentSubmit = useCallback(
     async (event: React.FormEvent<HTMLFormElement>) => {
       event.preventDefault();
@@ -1600,6 +1621,9 @@ const useWalikelasDashboard = (currentUser: CurrentUser | null) => {
     handleVerifyAll,
     attendancePercentage,
     studentsWithVerifiedGrades,
+    filteredReportStudents,
+    reportSearchTerm,
+    setReportSearchTerm,
     handlePrintReport,
     resetStudentForm,
     editStudent,

--- a/src/pages/walikelas/Dashboard.tsx
+++ b/src/pages/walikelas/Dashboard.tsx
@@ -62,6 +62,9 @@ const WalikelasaDashboard = ({ currentUser, onLogout }) => {
     handleVerifyAll,
     attendancePercentage,
     studentsWithVerifiedGrades,
+    filteredReportStudents,
+    reportSearchTerm,
+    setReportSearchTerm,
     handlePrintReport,
     resetStudentForm,
     editStudent,
@@ -852,12 +855,14 @@ const WalikelasaDashboard = ({ currentUser, onLogout }) => {
 
           {activeSection === "reports" && (
             <ReportsSection
-              students={studentsWithVerifiedGrades}
+              students={filteredReportStudents}
               grades={grades}
               selectedSemesterPeriodLabel={selectedSemesterPeriodLabel}
               selectedSemesterDateRange={selectedSemesterDateRange}
               selectedSemesterMetadata={selectedSemesterMetadata}
               onPrintReport={handlePrintReport}
+              searchTerm={reportSearchTerm}
+              onSearchChange={setReportSearchTerm}
             />
           )}
         </div>


### PR DESCRIPTION
## Summary
- add a dedicated report search state to the walikelas dashboard hook and expose filtered data
- render a searchable input in the reports section header and wire it to the filtered list
- cover the new report search behaviour with unit tests

## Testing
- npm run test -- ReportsSection

------
https://chatgpt.com/codex/tasks/task_e_6904eff70540833282c355acb353471a