### PR TITLE
Reorder subject code and name inputs

### DIFF
--- a/src/components/admin/SubjectManagement.tsx
+++ b/src/components/admin/SubjectManagement.tsx
@@ -269,20 +269,6 @@ export default function SubjectManagement({
               </DialogHeader>
               <form onSubmit={handleSubjectSubmit} className="space-y-4">
                 <div className="space-y-2">
-                  <Label>Nama Mata Pelajaran *</Label>
-                  <Input
-                    value={subjectForm.nama}
-                    onChange={(e) =>
-                      setSubjectForm((prev) => ({
-                        ...prev,
-                        nama: e.target.value,
-                      }))
-                    }
-                    required
-                  />
-                </div>
-
-                <div className="space-y-2">
                   <Label>Kode Mata Pelajaran *</Label>
                   <Input
                     value={subjectForm.kode}
@@ -290,6 +276,20 @@ export default function SubjectManagement({
                       setSubjectForm((prev) => ({
                         ...prev,
                         kode: e.target.value,
+                      }))
+                    }
+                    required
+                  />
+                </div>
+
+                <div className="space-y-2">
+                  <Label>Nama Mata Pelajaran *</Label>
+                  <Input
+                    value={subjectForm.nama}
+                    onChange={(e) =>
+                      setSubjectForm((prev) => ({
+                        ...prev,
+                        nama: e.target.value,
                       }))
                     }
                     required


### PR DESCRIPTION
## Summary
- show the subject code input before the subject name input in the subject management form to match desired ordering

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_6904f316b1d08332b02f93320d588452