### PR TITLE
feat: link schedules to teacher subject relations

### DIFF
--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -1526,6 +1526,42 @@ const apiService = {
     }
   },
 
+  async getTeacherSubjectClassRelations() {
+    if (USE_API) {
+      const endpoints = [
+        `${API_BASE_URL}/admin/teacher-subject-classes`,
+        `${API_BASE_URL}/admin/teacher-subjects`,
+      ];
+
+      let lastNotFoundError = null;
+
+      for (const endpoint of endpoints) {
+        try {
+          const response = await this.authFetch(endpoint);
+          return extractScheduleDataOrThrow(
+            response,
+            "Gagal memuat relasi guru-mapel-kelas"
+          );
+        } catch (error) {
+          const err = error;
+          if (err && typeof err === "object" && err.code === 404) {
+            lastNotFoundError = err;
+            continue;
+          }
+          throw error;
+        }
+      }
+
+      if (lastNotFoundError) {
+        return [];
+      }
+
+      return [];
+    } else {
+      return [];
+    }
+  },
+
   async getAdminScheduleById(scheduleId) {
     if (USE_API) {
       const response = await this.authFetch(


### PR DESCRIPTION
## Summary
- add teacher-subject relation types, selectors, and derived helpers so schedule forms, tables, and detail dialogs surface relation data
- load teacher–subject–class relations from the API and expose a single relation selector that synchronizes teacher, subject, and class fields
- include the relation identifier when creating or updating schedules to keep server data and local views aligned

## Testing
- npm run lint *(fails: existing lint rule violations in unrelated modules)*

------
https://chatgpt.com/codex/tasks/task_e_690501468e64833296b3e23fa77ebeb2