### PR TITLE
Add teacher subject filtering to teacher dashboard schedules

### DIFF
--- a/src/pages/guru/Dashboard.tsx
+++ b/src/pages/guru/Dashboard.tsx
@@ -45,6 +45,7 @@ const TeacherDashboard = ({ currentUser, onLogout }: TeacherDashboardProps) => {
     setSelectedSemesterId,
     semesters,
     teacherSchedules,
+    teacherSubjectOptions,
     teacherScheduleFilters,
     updateTeacherScheduleFilters,
     isTeacherScheduleLoading,
@@ -173,6 +174,21 @@ const TeacherDashboard = ({ currentUser, onLogout }: TeacherDashboardProps) => {
     });
   }, [classes, subjects]);
 
+  const scheduleTeacherSubjectOptions = useMemo(() => {
+    if (!teacherSubjectOptions || teacherSubjectOptions.length === 0) {
+      return teacherSubjectOptions;
+    }
+
+    if (!scheduleFilters.kelasId) {
+      return teacherSubjectOptions;
+    }
+
+    return teacherSubjectOptions.filter((option) => {
+      if (!option.kelasId) return true;
+      return option.kelasId === scheduleFilters.kelasId;
+    });
+  }, [scheduleFilters.kelasId, teacherSubjectOptions]);
+
   const scheduleDayOptions = useMemo(
     () => ["Senin", "Selasa", "Rabu", "Kamis", "Jumat", "Sabtu"],
     []
@@ -291,6 +307,28 @@ const TeacherDashboard = ({ currentUser, onLogout }: TeacherDashboardProps) => {
                   {scheduleClassOptions.map((kelas) => (
                     <option key={String(kelas.id)} value={String(kelas.id)}>
                       {kelas.nama || getClassesName(kelas.id ?? "") || "Kelas"}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="text-sm font-medium text-muted-foreground">
+                  Filter Relasi Mapel
+                </label>
+                <select
+                  value={scheduleFilters.teacherSubjectId}
+                  onChange={(event) =>
+                    updateTeacherScheduleFilters({
+                      teacherSubjectId: event.target.value,
+                    })
+                  }
+                  className="mt-1 block w-full rounded-md border border-input bg-background px-3 py-2 text-sm shadow-sm focus:outline-none focus:ring-2 focus:ring-primary"
+                  disabled={teacherSubjectOptions.length === 0}
+                >
+                  <option value="">Semua relasi</option>
+                  {scheduleTeacherSubjectOptions.map((option) => (
+                    <option key={option.id} value={option.id}>
+                      {option.label}
                     </option>
                   ))}
                 </select>

--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -422,6 +422,7 @@ const apiService = {
       semester = null,
       kelasId = null,
       hari = null,
+      teacherSubjectId = null,
     } = {}
   ) {
     if (USE_API) {
@@ -435,6 +436,10 @@ const apiService = {
       if (kelasId)
         queryParts.push(`kelasId=${encodeURIComponent(kelasId)}`);
       if (hari) queryParts.push(`hari=${encodeURIComponent(hari)}`);
+      if (teacherSubjectId)
+        queryParts.push(
+          `teacherSubjectId=${encodeURIComponent(teacherSubjectId)}`
+        );
 
       const response = await this.authFetch(
         appendQuery(


### PR DESCRIPTION
## Summary
- capture teacher-subject relations in the teacher dashboard hook and expose selectable options for schedules
- add a teacher-subject relation selector in the dashboard schedule filters and wire it to the schedule loader
- allow the API service to forward the selected teacher-subject relation when requesting schedules

## Testing
- npm run lint *(fails: existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_690505473d788332823fe6ba4211f3de