### PR TITLE
Handle numeric keyed schedule data responses

### DIFF
--- a/src/services/apiService.js
+++ b/src/services/apiService.js
@@ -81,7 +81,25 @@ const extractScheduleDataOrThrow = (response, defaultMessage) => {
     throw error;
   }
 
-  return response?.data;
+  const data = response?.data;
+
+  if (Array.isArray(data)) {
+    return data;
+  }
+
+  if (data && typeof data === "object") {
+    const numericKeys = Object.keys(data).filter(
+      (key) => Number.isInteger(Number(key))
+    );
+
+    if (numericKeys.length > 0) {
+      return numericKeys
+        .sort((a, b) => Number(a) - Number(b))
+        .map((key) => data[key]);
+    }
+  }
+
+  return data;
 };
 
 const findLocalSemesterRecord = (semesterId, tahun, semester) => {


### PR DESCRIPTION
## Summary
- normalize schedule API responses that use numeric object keys
- ensure extractScheduleDataOrThrow returns a stable array for schedule tables

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_690585b61c8483329be1a2fcb3309234