### PR TITLE
Add reset filter control to admin student management panel

### DIFF
--- a/src/components/admin/UserManagement.tsx
+++ b/src/components/admin/UserManagement.tsx
@@ -84,6 +84,12 @@ export default function UserManagement({
     setJenisKelaminFilter("all");
   }, []);
 
+  const handleResetFilters = useCallback(() => {
+    setSearchTerm("");
+    setRoleFilter("all");
+    resetStudentFilters();
+  }, [resetStudentFilters]);
+
   // Validation functions
   const validateNISN = (nisn: string): boolean => {
     return /^\d{10}$/.test(nisn);
@@ -1082,6 +1088,16 @@ export default function UserManagement({
                 ))}
               </SelectContent>
             </Select>
+          )}
+
+          {shouldShowStudentFilters && (
+            <Button
+              variant="outline"
+              onClick={handleResetFilters}
+              className="w-full md:w-auto"
+            >
+              Reset Filter
+            </Button>
           )}
 
           {shouldShowStudentFilters && (


### PR DESCRIPTION
## Summary
- add a reusable handler to reset student-related filters in the admin user management view
- render a Reset Filter button in the admin panel so student filters can be cleared quickly

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69077ec761408332ab884a33d466c70c