### PR TITLE
Adjust walikelasId fallback priority in admin schedule management

### DIFF
--- a/src/components/admin/AdminScheduleManagement.tsx
+++ b/src/components/admin/AdminScheduleManagement.tsx
@@ -287,7 +287,6 @@ const WALIKELAS_ID_PATHS = [
   "walikelasTeacherId",
   "walikelas.id",
   "walikelas.teacherId",
-  "walikelas.userId",
   "kelas.walikelasId",
   "kelas.walikelasTeacherId",
   "class.walikelasId",
@@ -295,6 +294,7 @@ const WALIKELAS_ID_PATHS = [
   "teacherSubjectClass.walikelasId",
   "teacher_subject_class.walikelasId",
   "pivot.walikelasId",
+  "walikelas.userId",
 ];
 
 const WALIKELAS_NAME_PATHS = [


### PR DESCRIPTION
## Summary
- reorder the walikelasId candidate paths so userId is used only as the last fallback

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690780841c1c8332af8458b7cf2cac99