### PR TITLE
Handle subjectName variants in schedule management

### DIFF
--- a/src/components/admin/AdminScheduleManagement.tsx
+++ b/src/components/admin/AdminScheduleManagement.tsx
@@ -538,11 +538,14 @@ const buildTeacherSubjectOption = (
     toTextValue(
       getCandidateValue(relation, [
         "subjectNama",
+        "subjectName",
         "mapelNama",
         "subject.nama",
         "subject.name",
+        "subject.subjectName",
         "mapel.nama",
         "mapel.name",
+        "mapel.subjectName",
       ])
     ) || (subjectId && subjectNameMap?.get(subjectId)) || "";
 
@@ -786,6 +789,7 @@ export default function AdminScheduleManagement({
       const name =
         toTextValue(subject?.nama) ||
         toTextValue(subject?.name) ||
+        toTextValue(subject?.subjectName) ||
         toTextValue((subject as Record<string, unknown>)?.subjectNama);
       if (name) {
         map.set(id, name);
@@ -958,10 +962,13 @@ export default function AdminScheduleManagement({
         toTextValue(
           getCandidateValue(schedule, [
             "subjectNama",
+            "subjectName",
             "subject.nama",
             "subject.name",
+            "subject.subjectName",
             "mapel.nama",
             "mapel.name",
+            "mapel.subjectName",
           ])
         ) ||
         (subjectId ? subjectNameMap.get(subjectId) ?? "" : "");


### PR DESCRIPTION
## Summary
- allow subject name mapping to use the subjectName field from subject payloads
- recognize subjectName keys when deriving subject labels for teacher-subject options and schedule rows

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69078971a5208332a4d9fa2e8248732d