### PR TITLE
Fix ReferenceError in wali kelas dashboard hook

### DIFF
--- a/src/hooks/use-walikelas-dashboard.ts
+++ b/src/hooks/use-walikelas-dashboard.ts
@@ -276,6 +276,26 @@ const useWalikelasDashboard = (currentUser: CurrentUser | null) => {
     buildSemesterTitle,
   } = useDashboardSemester({ semesters });
 
+  const selectedSemesterMetadata = useMemo(() => {
+    if (selectedSemesterId) {
+      return resolveSemesterMetadata(selectedSemesterId);
+    }
+    if (isStrictModeActive && enforcedActiveSemester) {
+      return enforcedActiveSemester;
+    }
+    if (semesters.length === 1) {
+      return normalizeSemesterMetadata(semesters[0]);
+    }
+    return null;
+  }, [
+    enforcedActiveSemester,
+    isStrictModeActive,
+    normalizeSemesterMetadata,
+    resolveSemesterMetadata,
+    selectedSemesterId,
+    semesters,
+  ]);
+
   const getEffectiveSemesterId = useCallback(
     (customId?: string | number | null) => {
       if (customId) return String(customId);
@@ -367,26 +387,6 @@ const useWalikelasDashboard = (currentUser: CurrentUser | null) => {
       shouldAttachSemesterId,
     ]
   );
-
-  const selectedSemesterMetadata = useMemo(() => {
-    if (selectedSemesterId) {
-      return resolveSemesterMetadata(selectedSemesterId);
-    }
-    if (isStrictModeActive && enforcedActiveSemester) {
-      return enforcedActiveSemester;
-    }
-    if (semesters.length === 1) {
-      return normalizeSemesterMetadata(semesters[0]);
-    }
-    return null;
-  }, [
-    enforcedActiveSemester,
-    isStrictModeActive,
-    normalizeSemesterMetadata,
-    resolveSemesterMetadata,
-    selectedSemesterId,
-    semesters,
-  ]);
 
   useEffect(() => {
     if (!currentUser?.kelasId) {


### PR DESCRIPTION
## Summary
- define the selected semester memo before the request payload callback so it is initialized before use
- keep the callback dependencies aligned with the memoized metadata and continue returning it from the hook

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_6907938def0883329d32993fee1c8e7c